### PR TITLE
Add pre-push hook for local tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ -n "$SKIP_PRE_PUSH_TESTS" ]; then
+    echo "Skipping pre-push tests because SKIP_PRE_PUSH_TESTS is set."
+    exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "Running pre-push tests: ./gradlew testDebugUnitTest"
+./gradlew testDebugUnitTest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Build a debug APK:
 ./gradlew assembleDebug
 ```
 
+Local checks before push:
+```bash
+./scripts/install-git-hooks.sh
+```
+This installs a pre-push hook that runs `./gradlew testDebugUnitTest`. To skip once: `SKIP_PRE_PUSH_TESTS=1 git push`.
+
 If you do not have the Gradle wrapper JAR yet, generate it once with:
 ```bash
 gradle wrapper

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+HOOKS_DIR="$REPO_ROOT/.githooks"
+TARGET_DIR="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+    echo "Missing $HOOKS_DIR"
+    exit 1
+fi
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "Missing $TARGET_DIR"
+    exit 1
+fi
+
+cp "$HOOKS_DIR/pre-push" "$TARGET_DIR/pre-push"
+chmod +x "$TARGET_DIR/pre-push"
+
+echo "Installed pre-push hook."


### PR DESCRIPTION
## Summary
- add a pre-push hook that runs ./gradlew testDebugUnitTest
- provide a small installer script for local git hooks
- document the pre-push testing flow and skip override
