### PR TITLE
Rename app package to net.hlan.sushi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.sushi.sshclient
+          packageName: net.hlan.sushi
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: ${{ needs.create-release.outputs.play-track }}
           status: completed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ It summarizes build/test commands and local coding conventions.
 ## Project summary
 - Android app built with Gradle (Kotlin DSL).
 - Single module: `app`.
-- Package: `com.sushi.sshclient`.
+- Package: `net.hlan.sushi`.
 - UI uses view binding (no Compose).
 ## Environment
 - JDK 17 required.
@@ -44,7 +44,7 @@ Unit tests (JVM):
 ```
 Run a single unit test method:
 ```bash
-./gradlew testDebugUnitTest --tests "com.sushi.sshclient.ExampleUnitTest.testAddition_isCorrect"
+./gradlew testDebugUnitTest --tests "net.hlan.sushi.ExampleUnitTest.testAddition_isCorrect"
 ```
 Instrumented tests (device/emulator):
 ```bash
@@ -54,12 +54,12 @@ Instrumented tests (device/emulator):
 Run a single instrumented test class:
 ```bash
 ./gradlew connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=com.sushi.sshclient.ExampleInstrumentedTest
+  -Pandroid.testInstrumentationRunnerArguments.class=net.hlan.sushi.ExampleInstrumentedTest
 ```
 Run a single instrumented test method:
 ```bash
 ./gradlew connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=com.sushi.sshclient.ExampleInstrumentedTest#useAppContext
+  -Pandroid.testInstrumentationRunnerArguments.class=net.hlan.sushi.ExampleInstrumentedTest#useAppContext
 ```
 Device tests require an emulator or physical device.
 ## Kotlin & formatting

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Prerequisites:
 
 Optional integrations:
 - Gemini voice mode: add your API key in app settings.
-- Google Drive logs: create an OAuth client for the package `com.sushi.sshclient` and enable the Drive API.
+- Google Drive logs: create an OAuth client for the package `net.hlan.sushi` and enable the Drive API.
 
 Build a debug APK:
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,11 +15,11 @@ val hasKeystore = !keystorePath.isNullOrBlank() &&
     !keyPassword.isNullOrBlank()
 
 android {
-    namespace = "com.sushi.sshclient"
+    namespace = "net.hlan.sushi"
     compileSdk = 36
 
     defaultConfig {
-        applicationId = "com.sushi.sshclient"
+        applicationId = "net.hlan.sushi"
         minSdk = 24
         targetSdk = 36
         versionCode = versionCodeOverride ?: 1

--- a/app/src/androidTest/java/net/hlan/sushi/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -11,6 +11,6 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.sushi.sshclient", appContext.packageName)
+        assertEquals("net.hlan.sushi", appContext.packageName)
     }
 }

--- a/app/src/main/java/net/hlan/sushi/ConsoleLogRepository.kt
+++ b/app/src/main/java/net/hlan/sushi/ConsoleLogRepository.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 

--- a/app/src/main/java/net/hlan/sushi/DriveAuthManager.kt
+++ b/app/src/main/java/net/hlan/sushi/DriveAuthManager.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/net/hlan/sushi/DriveLogSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/DriveLogSettings.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 

--- a/app/src/main/java/net/hlan/sushi/DriveLogUploader.kt
+++ b/app/src/main/java/net/hlan/sushi/DriveLogUploader.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.accounts.Account
 import android.content.Context

--- a/app/src/main/java/net/hlan/sushi/GeminiClient.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiClient.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 import org.json.JSONArray

--- a/app/src/main/java/net/hlan/sushi/GeminiSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiSettings.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.Manifest
 import android.app.Activity
@@ -9,7 +9,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import com.sushi.sshclient.databinding.ActivityMainBinding
+import net.hlan.sushi.databinding.ActivityMainBinding
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/net/hlan/sushi/SecurePrefs.kt
+++ b/app/src/main/java/net/hlan/sushi/SecurePrefs.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -1,11 +1,11 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import android.app.Activity
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import com.sushi.sshclient.databinding.ActivitySettingsBinding
+import net.hlan.sushi.databinding.ActivitySettingsBinding
 
 class SettingsActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingsBinding

--- a/app/src/test/java/net/hlan/sushi/ExampleUnitTest.kt
+++ b/app/src/test/java/net/hlan/sushi/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.sushi.sshclient
+package net.hlan.sushi
 
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
## Summary
- move Kotlin sources/tests to the net.hlan.sushi package
- update namespace/applicationId and release workflow package name
- refresh docs and test commands for the new package
