### PR TITLE
Enable release minification and mapping upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,5 +198,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: net.hlan.sushi
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
           track: ${{ needs.create-release.outputs.play-track }}
           status: completed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
             if (hasKeystore) {
                 signingConfig = signingConfigs.getByName("release")
             }
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## Summary
- enable R8 minification for release builds to generate mapping.txt
- upload the release mapping file to Google Play during CI releases
