### PR TITLE
Fix R8 missing class errors

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,3 +7,8 @@
 # -keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #     public *;
 # }
+
+# Silence missing platform classes referenced by Apache HTTP/GSS code paths.
+-dontwarn javax.naming.**
+-dontwarn org.ietf.jgss.**
+-dontwarn org.apache.http.**


### PR DESCRIPTION
## Summary
- suppress missing platform classes referenced by Apache HTTP/GSS code paths
- allow release minification to complete so mapping.txt can be generated
