### PR TITLE
fix: preserve SSH on rotation, add terminal font size (#34, #35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+Sushi is an Android SSH client (package `net.hlan.sushi`, min SDK 24, target SDK 36). Single Gradle module `:app`, Kotlin DSL, JDK 17 required.
+
+## Build commands
+
+```bash
+./gradlew assembleDebug
+./gradlew assembleRelease
+./gradlew lint                          # or lintDebug
+./gradlew testDebugUnitTest             # JVM unit tests
+./gradlew testDebugUnitTest --tests "net.hlan.sushi.ExampleUnitTest.testAddition_isCorrect"
+./gradlew connectedDebugAndroidTest     # requires device/emulator
+./gradlew connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=net.hlan.sushi.JschRuntimeTest
+```
+
+Lint reports go to `app/build/reports/`.
+
+### Local dev scripts
+
+```bash
+./scripts/install-wifi-debug.sh [device]   # build + install via Wi-Fi ADB (auto-bumps versionCode)
+./scripts/run-device-qa-suite.sh           # runs instrumented QA suite on device
+./scripts/setup-local-ssh-test.sh          # wizard to store SSH test credentials
+./scripts/run-local-ssh-test.sh            # runs LocalSshIntegrationTest
+./scripts/install-git-hooks.sh             # installs pre-push hook (runs unit tests)
+```
+
+Skip the pre-push hook with `SKIP_PRE_PUSH_TESTS=1 git push`.
+
+## Architecture
+
+Activity-based (no Compose, no ViewModel/MVVM). UI logic stays in activities; business logic goes into helper classes.
+
+**Key helpers:**
+- `SshClient` — JSch wrapper; handles password/key auth, jump servers, PTY sessions. JSch classes are kept in ProGuard (`proguard-rules.pro`) because JSch loads crypto providers via reflection.
+- `GeminiClient` — Gemini API over raw `HttpURLConnection` (no SDK).
+- `DriveAuthManager` / `DriveLogUploader` — Google OAuth + Drive API for log uploads.
+- `PlayRunner` — Executes automated scripts ("Plays") with `{{ PARAM }}` template placeholders.
+- `SecurePrefs` — AES256-GCM encrypted SharedPreferences; use for all secrets (API keys, tokens).
+- `PhraseDatabaseHelper` / `PlayDatabaseHelper` — SQLite via `SQLiteOpenHelper`. `PhraseDatabaseHelper` exposes a `MutableStateFlow` for reactive UI updates.
+- `ConsoleLogRepository` / `TerminalLogRepository` — Session log persistence.
+
+**UI navigation:**
+- `MainActivity` — `ViewPager2` with Terminal and Plays tabs; complex page binding setup in `onCreate`.
+- `SettingsActivity` — `ViewPager2` carousel with General, SSH, Gemini, Drive pages.
+- `TerminalActivity` — interactive SSH terminal using the custom `TerminalView`.
+
+**Threading:** Legacy code uses `Thread { ... }` / `runOnUiThread { ... }`. Newer code uses `lifecycleScope.launch` + `Dispatchers.IO`. Do not mix styles within a new feature; follow the existing pattern in the file you're editing.
+
+**Data storage:** `SecurePrefs` for secrets, standard `SharedPreferences` for non-sensitive settings, SQLite for phrases/plays.
+
+## Coding conventions
+
+- Kotlin official style, 4-space indent, no wildcard imports.
+- `val` by default; `var` only when mutation is required.
+- Null safety: prefer non-null, early-return on null with `orEmpty()` for strings.
+- Error handling at module boundaries: `runCatching { ... }.getOrElse { ... }`.
+- All user-visible strings in `app/src/main/res/values/strings.xml`.
+- View binding (`binding.*`) instead of `findViewById`.
+- One top-level class per file.
+- Resource IDs: `lower_snake_case`; layout files: `activity_*.xml`.
+
+## Adding features
+
+- New settings → `SettingsActivity` + store secrets in `SecurePrefs`.
+- New dependencies → `app/build.gradle.kts`.
+- New permissions → `AndroidManifest.xml` (only when necessary).
+- JSch crypto classes referenced only by name → add to `proguard-rules.pro` to prevent stripping.
+
+## Build types
+
+- `debug` — standard debug.
+- `release` — minified with ProGuard; signing via env vars (`ANDROID_KEYSTORE_PATH`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`).
+- `minifiedDebug` — debug APK with minification enabled; used for instrumented tests to catch ProGuard issues.
+
+## SSH test credentials
+
+Stored in `.local/local-ssh-test.env` (chmod 600, git-ignored). Set up via `./scripts/setup-local-ssh-test.sh`.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,8 @@
 -keep class com.jcraft.jsch.UserAuthGSSAPIWithMIC { *; }
 -keep class com.jcraft.jsch.jce.** { *; }
 -keep class com.jcraft.jsch.jcraft.** { *; }
+
+# ListAdapter.getCurrentList() is called from instrumented tests against the minified build.
+-keepclassmembers class * extends androidx.recyclerview.widget.ListAdapter {
+    public java.util.List getCurrentList();
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,7 @@
             android:label="@string/about_title" />
         <activity
             android:name=".TerminalActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:exported="false"
             android:label="@string/terminal_title" />
     </application>

--- a/app/src/main/java/net/hlan/sushi/AppThemeSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/AppThemeSettings.kt
@@ -25,6 +25,15 @@ class AppThemeSettings(context: Context) {
         AppCompatDelegate.setDefaultNightMode(mode.nightMode)
     }
 
+    fun getTerminalFontSize(): TerminalFontSize {
+        val raw = prefs.getInt(KEY_TERMINAL_FONT_SIZE, TerminalFontSize.MEDIUM.storageValue)
+        return TerminalFontSize.fromStorageValue(raw)
+    }
+
+    fun setTerminalFontSize(size: TerminalFontSize) {
+        prefs.edit().putInt(KEY_TERMINAL_FONT_SIZE, size.storageValue).apply()
+    }
+
     enum class ThemeMode(val storageValue: Int, val nightMode: Int) {
         AUTO(0, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM),
         LIGHT(1, AppCompatDelegate.MODE_NIGHT_NO),
@@ -37,8 +46,22 @@ class AppThemeSettings(context: Context) {
         }
     }
 
+    enum class TerminalFontSize(val storageValue: Int, val sp: Float) {
+        SMALL(0, 12f),
+        MEDIUM(1, 14f),
+        LARGE(2, 16f),
+        XL(3, 20f);
+
+        companion object {
+            fun fromStorageValue(value: Int): TerminalFontSize {
+                return entries.firstOrNull { it.storageValue == value } ?: MEDIUM
+            }
+        }
+    }
+
     companion object {
         private const val PREFS_NAME = "app_theme"
         private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_TERMINAL_FONT_SIZE = "terminal_font_size"
     }
 }

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -60,6 +60,14 @@ class SettingsActivity : AppCompatActivity() {
             ThemeOption(AppThemeSettings.ThemeMode.DARK, getString(R.string.theme_mode_dark))
         )
     }
+    private val fontSizeOptions by lazy {
+        listOf(
+            FontSizeOption(AppThemeSettings.TerminalFontSize.SMALL, getString(R.string.terminal_font_size_small)),
+            FontSizeOption(AppThemeSettings.TerminalFontSize.MEDIUM, getString(R.string.terminal_font_size_medium)),
+            FontSizeOption(AppThemeSettings.TerminalFontSize.LARGE, getString(R.string.terminal_font_size_large)),
+            FontSizeOption(AppThemeSettings.TerminalFontSize.XL, getString(R.string.terminal_font_size_xl))
+        )
+    }
     private var pendingApiKey: String = ""
     private var lastConnectionDiagnostics: String = ""
 
@@ -169,6 +177,7 @@ class SettingsActivity : AppCompatActivity() {
         generalPageBinding = pageBinding
         setupLanguagePicker(pageBinding)
         setupThemePicker(pageBinding)
+        setupFontSizePicker(pageBinding)
 
         pageBinding.managePlaysButton.setOnClickListener {
             startActivity(Intent(this, PlaysActivity::class.java))
@@ -317,6 +326,21 @@ class SettingsActivity : AppCompatActivity() {
         pageBinding.themeModeInput.setOnItemClickListener { _, _, position, _ ->
             val option = themeOptions.getOrNull(position) ?: return@setOnItemClickListener
             appThemeSettings.setThemeMode(option.mode)
+        }
+    }
+
+    private fun setupFontSizePicker(pageBinding: PageSettingsGeneralBinding) {
+        val labels = fontSizeOptions.map { it.label }
+        val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, labels)
+        pageBinding.terminalFontSizeInput.setAdapter(adapter)
+
+        val selected = fontSizeOptions.firstOrNull { it.size == appThemeSettings.getTerminalFontSize() }
+            ?: fontSizeOptions[1]
+        pageBinding.terminalFontSizeInput.setText(selected.label, false)
+
+        pageBinding.terminalFontSizeInput.setOnItemClickListener { _, _, position, _ ->
+            val option = fontSizeOptions.getOrNull(position) ?: return@setOnItemClickListener
+            appThemeSettings.setTerminalFontSize(option.size)
         }
     }
 
@@ -537,6 +561,11 @@ class SettingsActivity : AppCompatActivity() {
 
     private data class ThemeOption(
         val mode: AppThemeSettings.ThemeMode,
+        val label: String
+    )
+
+    private data class FontSizeOption(
+        val size: AppThemeSettings.TerminalFontSize,
         val label: String
     )
 

--- a/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
@@ -18,6 +18,7 @@ import net.hlan.sushi.databinding.ActivityTerminalBinding
 class TerminalActivity : AppCompatActivity() {
     private lateinit var binding: ActivityTerminalBinding
     private val sshSettings by lazy { SshSettings(this) }
+    private val appThemeSettings by lazy { AppThemeSettings(this) }
     private val terminalLogRepository by lazy { TerminalLogRepository(this) }
     private val driveLogSettings by lazy { DriveLogSettings(this) }
     private val driveAuthManager by lazy { DriveAuthManager(this) }
@@ -46,6 +47,8 @@ class TerminalActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityTerminalBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.terminalOutputText.textSize = appThemeSettings.getTerminalFontSize().sp
 
         binding.terminalOutputText.onSizeChangedListener = { col, row, wp, hp ->
             sshClient?.resizePty(col, row, wp, hp)

--- a/app/src/main/res/layout/page_settings_general.xml
+++ b/app/src/main/res/layout/page_settings_general.xml
@@ -73,6 +73,37 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
+            android:id="@+id/terminalFontSectionTitle"
+            style="@style/TextAppearance.Sushi.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/terminal_font_section_title" />
+
+        <TextView
+            android:id="@+id/terminalFontSectionSubtitle"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/terminal_font_section_subtitle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/terminalFontSizeLayout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="@string/terminal_font_size_label">
+
+            <AutoCompleteTextView
+                android:id="@+id/terminalFontSizeInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
             android:id="@+id/managementSectionTitle"
             style="@style/TextAppearance.Sushi.Body"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,6 +293,14 @@
     <string name="play_desc_change_password">Change one user password on the selected host.</string>
     <string name="play_host_item">%1$s</string>
     <string name="play_host_item_active">%1$s (active)</string>
+    <string name="terminal_font_section_title">Terminal font size</string>
+    <string name="terminal_font_section_subtitle">Adjust the text size in the terminal view.</string>
+    <string name="terminal_font_size_label">Font size</string>
+    <string name="terminal_font_size_small">Small</string>
+    <string name="terminal_font_size_medium">Medium</string>
+    <string name="terminal_font_size_large">Large</string>
+    <string name="terminal_font_size_xl">Extra Large</string>
+
     <plurals name="import_success_toast">
         <item quantity="one">Imported %d phrase</item>
         <item quantity="other">Imported %d phrases</item>


### PR DESCRIPTION
## Summary
- **Fix #34** — Add `android:configChanges` to `TerminalActivity` so orientation changes no longer destroy the activity and disconnect the SSH session. PTY resize is already handled by the existing `onSizeChanged` callback.
- **Fix #35** — Add a terminal font size picker (Small 12sp / Medium 14sp / Large 16sp / XL 20sp) to Settings > General, persisted in `SharedPreferences` via `AppThemeSettings`, applied when the terminal opens.
- **ProGuard fix** — Keep `ListAdapter.getCurrentList()` which R8 was stripping from the minified build, causing a `NoSuchMethodError` in the QA suite.

## Test plan
- [x] `assembleDebug` builds successfully
- [x] `connectedDebugAndroidTest` passes on Nokia G42 5G (Android 15) — 18 tests, 0 failures
- [ ] Manual: open terminal session, rotate device — session stays connected
- [ ] Manual: change font size in Settings > General, reopen terminal — font size applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)