### PR TITLE
fix(CommandSafety): handle chained commands and fix regex safe-pattern matching

### DIFF
--- a/app/src/main/java/net/hlan/sushi/CommandSafety.kt
+++ b/app/src/main/java/net/hlan/sushi/CommandSafety.kt
@@ -20,25 +20,32 @@ object CommandSafety {
 
     /**
      * Classify a command's safety level.
-     * 
+     *
+     * Blocked patterns are matched against the full command string so that
+     * multi-token patterns (e.g. the fork-bomb `:(){ :|:& };:`) remain
+     * detectable even though they contain shell operators.
+     *
+     * After the blocked check the command is split on `;`, `&&`, `||`, and `|`
+     * so that a safe-looking first segment cannot hide a non-safe second one
+     * (e.g. `ls && apt-get install foo` is CONFIRM, not SAFE).
+     *
      * @param command The shell command to classify
      * @return SafetyLevel indicating whether the command is safe, needs confirmation, or is blocked
      */
     fun classify(command: String): SafetyLevel {
         val normalized = command.trim().lowercase(Locale.ROOT)
 
-        // Check blocked patterns first (highest priority)
-        if (isBlocked(normalized)) {
-            return SafetyLevel.BLOCKED
-        }
+        // Blocked check runs on the whole string first (highest priority).
+        if (isBlocked(normalized)) return SafetyLevel.BLOCKED
 
-        // Check safe patterns
-        if (isSafe(normalized)) {
-            return SafetyLevel.SAFE
-        }
+        // Split on common shell operators and require every segment to be safe.
+        val segments = normalized
+            .split(Regex("&&|\\|\\||[;|]"))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
 
-        // Default to CONFIRM for anything not explicitly safe or blocked
-        return SafetyLevel.CONFIRM
+        if (segments.any { !isSafe(it) }) return SafetyLevel.CONFIRM
+        return SafetyLevel.SAFE
     }
 
     /**
@@ -177,7 +184,7 @@ object CommandSafety {
             Regex("^docker\\s+inspect")
         )
 
-        return safePatterns.any { pattern -> pattern.matches(command) }
+        return safePatterns.any { pattern -> pattern.containsMatchIn(command) }
     }
 
     /**

--- a/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
+++ b/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
@@ -1,0 +1,211 @@
+package net.hlan.sushi
+
+import net.hlan.sushi.CommandSafety.SafetyLevel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CommandSafetyTest {
+
+    // -------------------------------------------------------------------------
+    // SAFE commands
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun safeCommand_ls() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("ls"))
+    }
+
+    @Test
+    fun safeCommand_lsWithArgs() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("ls -la /var/log"))
+    }
+
+    @Test
+    fun safeCommand_pwd() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("pwd"))
+    }
+
+    @Test
+    fun safeCommand_cat() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("cat /etc/os-release"))
+    }
+
+    @Test
+    fun safeCommand_grep() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("grep -r foo /var/log"))
+    }
+
+    @Test
+    fun safeCommand_ps() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("ps aux"))
+    }
+
+    @Test
+    fun safeCommand_df() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("df -h"))
+    }
+
+    @Test
+    fun safeCommand_whoami() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("whoami"))
+    }
+
+    @Test
+    fun safeCommand_caseInsensitive() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("LS -LA"))
+    }
+
+    // -------------------------------------------------------------------------
+    // SAFE pattern-based commands (regression for matches() → containsMatchIn())
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun safePattern_systemctlStatusWithUnit() {
+        // Previously broken: matches() required full-string match, so "systemctl status nginx"
+        // never matched Regex("^systemctl\\s+status") and fell through to CONFIRM.
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("systemctl status nginx"))
+    }
+
+    @Test
+    fun safePattern_systemctlStatusNoUnit() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("systemctl status"))
+    }
+
+    @Test
+    fun safePattern_systemctlListUnits() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("systemctl list-units --type=service"))
+    }
+
+    @Test
+    fun safePattern_systemctlIsActive() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("systemctl is-active sshd"))
+    }
+
+    @Test
+    fun safePattern_journalctl() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("journalctl -u nginx -f"))
+    }
+
+    @Test
+    fun safePattern_dockerPs() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("docker ps -a"))
+    }
+
+    @Test
+    fun safePattern_dockerLogs() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("docker logs my-container"))
+    }
+
+    @Test
+    fun safePattern_aptList() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("apt list --installed"))
+    }
+
+    @Test
+    fun safePattern_dpkgList() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("dpkg -l"))
+    }
+
+    @Test
+    fun safePattern_vcgencmdTemp() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("vcgencmd measure_temp"))
+    }
+
+    // -------------------------------------------------------------------------
+    // BLOCKED commands
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun blocked_shutdown() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("shutdown now"))
+    }
+
+    @Test
+    fun blocked_reboot() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("reboot"))
+    }
+
+    @Test
+    fun blocked_rmRfRoot() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("rm -rf /"))
+    }
+
+    @Test
+    fun blocked_mkfs() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("mkfs.ext4 /dev/sda1"))
+    }
+
+    @Test
+    fun blocked_systemctlReboot() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("systemctl reboot"))
+    }
+
+    @Test
+    fun blocked_forkBomb() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify(":(){ :|:& };:"))
+    }
+
+    // -------------------------------------------------------------------------
+    // CONFIRM commands
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun confirm_aptGetInstall() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("apt-get install vim"))
+    }
+
+    @Test
+    fun confirm_systemctlStart() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("systemctl start nginx"))
+    }
+
+    @Test
+    fun confirm_systemctlStop() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("systemctl stop nginx"))
+    }
+
+    @Test
+    fun confirm_touch() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("touch /tmp/foo"))
+    }
+
+    @Test
+    fun confirm_mkdir() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("mkdir /tmp/newdir"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Chained commands — SAFE first segment must not hide a dangerous second
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun chain_safeAndConfirm_semicolon() {
+        // Previously broken: "ls" matched SAFE, remaining "; apt-get install foo" was ignored.
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("ls; apt-get install foo"))
+    }
+
+    @Test
+    fun chain_safeAndConfirm_and() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("pwd && systemctl start nginx"))
+    }
+
+    @Test
+    fun chain_safeAndBlocked_or() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("echo hi || shutdown now"))
+    }
+
+    @Test
+    fun chain_safeAndBlocked_pipe() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("cat /etc/fstab | reboot"))
+    }
+
+    @Test
+    fun chain_bothSafe() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("ls -la | grep foo"))
+    }
+
+    @Test
+    fun chain_confirmAndBlocked() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("apt-get install vim && reboot"))
+    }
+}


### PR DESCRIPTION
Two bugs fixed in CommandSafety.classify():

1. `isSafe()` used `Regex.matches()` which performs a full-string match, so
   patterns like `^systemctl\s+status` never matched real commands such as
   `systemctl status nginx` (because extra tokens after the subcommand weren't
   covered by the pattern). Changed to `containsMatchIn()` so anchored prefixes
   work as intended.

2. `classify()` only inspected the first command in a chained expression, so
   `ls && apt-get install foo` was classified SAFE because the first word is
   `ls`. The function now splits the input on `;`, `&&`, `||`, and `|` and
   requires every segment to pass the safe check. The blocked check still runs
   on the full string first so that multi-token patterns such as the fork-bomb
   `:(){ :|:& };:` remain detectable after the introduction of splitting.

Adds CommandSafetyTest covering SAFE, CONFIRM, BLOCKED, and chained-command
cases — including regression tests for both bugs.

https://claude.ai/code/session_0192evsLWviKfagHmQ1eC2Cs