### PR TITLE
docs: local-shell terminal + host-selection rework — concepts and roadmap

### DIFF
--- a/docs/ROADMAP_LOCAL_SHELL.md
+++ b/docs/ROADMAP_LOCAL_SHELL.md
@@ -1,0 +1,225 @@
+# Roadmap: Local-shell terminal + host-selection rework
+
+Phased implementation plan for adding a local-shell terminal to Sushi and
+fixing the host-selection UX along the way. The *what* and *why* live in the
+concept docs under [`./concepts/`](./concepts/) — this file is the *how* and
+*when*.
+
+## Goal
+
+Ship a local-shell terminal on the Android device with a real PTY (so `vi`,
+`top`, `less` work), surfaced as just another host in the existing host list.
+Reduce the taps-to-connection cost for known hosts from 6–8 down to 1.
+
+**Out of scope:** PlayRunner and Gemini wiring against the local backend —
+held for the future "renaissance" where Gemini sits on top of the terminal
+abstraction and emphasises observability of plans-vs-results.
+
+## Concepts
+
+The implementation is structured around four concepts. Read them before
+starting the corresponding branch:
+
+- [`./concepts/TERMINAL_BACKEND.md`](./concepts/TERMINAL_BACKEND.md) — the
+  Kotlin interface that captures the PTY contract shared by SSH and local
+  sessions.
+- [`./concepts/HOST_KIND.md`](./concepts/HOST_KIND.md) — the
+  `HostKind { SSH, LOCAL }` discriminator on `SshConnectionConfig`, the
+  synthetic Local host seeded on first launch, and the `displayTarget()`
+  extension that gives every label the kind suffix for free.
+- [`./concepts/LOCAL_SHELL_PTY.md`](./concepts/LOCAL_SHELL_PTY.md) — the
+  `LocalShellBackend` and its small JNI shim around `forkpty()`. Includes the
+  Gradle/NDK/ProGuard wiring and the rationale for not adopting Termux's
+  GPL-licensed emulator library.
+- [`./concepts/HOST_SELECTION_UX.md`](./concepts/HOST_SELECTION_UX.md) — the
+  four targeted UX fixes (one-tap connect, drop silent auto-select, settings
+  dedup, kind-aware connect-button label).
+
+## Dependency graph
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 1 — TerminalBackend abstraction (no user-visible change)  │
+│   SshClient ──implements──▶ TerminalBackend                      │
+│   SshConnectionHolder ─▶ TerminalBackend  (+ legacy SshClient?)  │
+│   ConversationManager: unchanged (renaissance defers it)         │
+└──────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 2 — Local backend + JNI PTY                               │
+│   HostKind {SSH, LOCAL} on SshConnectionConfig (default SSH;     │
+│       Moshi Kotlin defaults handle old persisted JSON)           │
+│   LocalShellBackend ──JNI──▶ libsushi-pty.so (forkpty,           │
+│                              ~100 LOC C, no GPL dependency)      │
+│   Synthetic Local host seeded on first launch                    │
+└──────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 3 — Host-selection UX                                     │
+│   HostsActivity row tap ──▶ TerminalActivity.createIntent(       │
+│                                  autoConnect = true)             │
+│   Drop silent first-host auto-select; dedup Settings buttons     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The branches are sequential:
+
+- Branch 2 depends on the `TerminalBackend` interface from Branch 1 — without
+  it, `LocalShellBackend` has nothing to plug into.
+- Branch 3's connect-button kind suffix needs the `displayTarget()` extension
+  from Branch 2. The other three Branch 3 fixes (one-tap connect, drop
+  auto-select, settings dedup) are independent and could ship sooner if the
+  team chooses, but bundling them keeps the UX story coherent in one
+  release.
+
+Each branch passes through SonarQube before merge and may cut a release on
+main.
+
+---
+
+## Branch 1 — TerminalBackend abstraction
+
+**User-visible change:** none. This is a refactor that establishes the seam
+for Branch 2.
+
+**Edits:**
+
+- New file `app/src/main/java/net/hlan/sushi/TerminalBackend.kt` — the
+  interface.
+- `app/src/main/java/net/hlan/sushi/SshClient.kt:71` — add `: TerminalBackend`
+  to the class declaration. Existing method signatures already match.
+- `app/src/main/java/net/hlan/sushi/SshConnectionHolder.kt` — full rewrite
+  (small file). Holds both `TerminalBackend?` (primary) and `SshClient?`
+  (legacy, non-null only when the active backend is SSH). Adds
+  `getActiveBackend()` and `getActiveSshClient()` accessors.
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt:29` — change field
+  type to `TerminalBackend?`. Line 290 helper `connectWithClient(config)`
+  changes its return type to `Pair<TerminalBackend, SshConnectResult>`.
+- `app/src/main/java/net/hlan/sushi/MainActivity.kt:878` — switch from
+  `SshConnectionHolder.getActiveClient()` to `getActiveSshClient()`.
+- `ConversationManager`, `PlayRunner`, `PersonaClient`, `ShareActivity`,
+  `SettingsActivity` SSH test path, and `LocalSshIntegrationTest` are
+  **untouched** — they keep typing on `SshClient` directly.
+
+**Verify:**
+
+- `./gradlew testDebugUnitTest` — existing tests pass with `SshClient`
+  implementing `TerminalBackend`.
+- `./gradlew lint` clean (or only the existing baseline lint).
+- `./scripts/install-wifi-debug.sh` to a real device. Open an existing SSH
+  host: connect, type, send Ctrl+C, rotate the screen (resize), disconnect.
+  Behaviour identical to today.
+
+---
+
+## Branch 2 — Local backend + JNI PTY
+
+**User-visible change:** a new "Local shell" host appears in `HostsActivity`.
+Tapping it opens a real PTY shell on the device. Existing SSH hosts behave
+unchanged.
+
+**Edits:**
+
+- `app/src/main/java/net/hlan/sushi/SshClient.kt` (lines 14-53) — add
+  `enum class HostKind { SSH, LOCAL }` and the `kind: HostKind = HostKind.SSH`
+  field on `SshConnectionConfig`. Extend `displayTarget()` to append the
+  kind suffix.
+- `app/src/main/java/net/hlan/sushi/SshSettings.kt` — store `Context` as a
+  field; add `seedLocalHostIfMissing()`.
+- `app/src/main/java/net/hlan/sushi/SushiApplication.kt` — call
+  `SshSettings(this).seedLocalHostIfMissing()` in `onCreate`.
+- New file `app/src/main/java/net/hlan/sushi/LocalShellBackend.kt`.
+- New file `app/src/main/cpp/sushi-pty.c`.
+- New file `app/src/main/cpp/CMakeLists.txt`.
+- `app/build.gradle.kts` — `ndkVersion`, `externalNativeBuild { cmake { ... } }`,
+  `defaultConfig.ndk.abiFilters`.
+- `app/proguard-rules.pro` — keep native methods and `LocalShellBackend`.
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt:110-127` — branch on
+  `config.kind` to construct the right backend; guard the SSH retry loop
+  (lines 131-145) with `if (config.kind == HostKind.SSH)`.
+- `app/src/main/java/net/hlan/sushi/HostEditActivity.kt` — hide SSH-only
+  fields when `kind == LOCAL`; disable **Delete** for the synthetic Local
+  host; skip host/username validation for LOCAL.
+- `app/src/main/res/values/strings.xml` — new strings:
+  `local_shell_default_alias`, kind labels.
+
+**Verify:**
+
+- New unit test `app/src/test/java/net/hlan/sushi/LocalShellBackendTest.kt`:
+  start backend, write `echo hello\n`, assert `"hello"` appears in `onLine`,
+  disconnect cleanly, exit code = 0. If JNI loading is awkward in JVM unit
+  tests, promote to `app/src/androidTest/`.
+- New instrumented test path in `app/src/androidTest/`: open the synthetic
+  Local host → `TerminalActivity` connects → run `ls /` (assert output
+  contains `system`) → run `vi /tmp/x`, type `:q!`, exit cleanly (asserts a
+  real PTY) → disconnect.
+- `./gradlew assembleRelease` then install — confirm the minified release
+  loads `libsushi-pty.so` and that the synthetic Local host opens (i.e.
+  ProGuard did not strip JNI methods or the `LocalShellBackend` class).
+- `./gradlew connectedDebugAndroidTest` on an `x86_64` emulator — confirms
+  ABI coverage.
+- Real-device regression of all three SSH user flows (read+copy a file,
+  restart a service, run a maintenance script).
+- Persistence check: install over an older build that has saved SSH hosts.
+  Confirm those hosts deserialise as `kind = SSH`. Inspect with
+  `adb shell run-as net.hlan.sushi cat files/...` if needed.
+- `./scripts/run-device-qa-suite.sh` clean.
+
+---
+
+## Branch 3 — Host-selection UX
+
+**User-visible change:** tapping a host in `HostsActivity` opens a connected
+session in one tap. Settings → SSH no longer shows duplicate Manage Hosts /
+Quick Add Host buttons. Saving a new host no longer silently activates it.
+
+**Edits:**
+
+- `app/src/main/java/net/hlan/sushi/HostsActivity.kt:20-31` — `onHostClick`
+  becomes `setActiveHostId(host.id)` + `startActivity(TerminalActivity.createIntent(this, autoConnect = true))` + `finish()`.
+- `app/src/main/java/net/hlan/sushi/HostEditActivity.kt:128-131` — delete the
+  silent first-host auto-select block.
+- `app/src/main/java/net/hlan/sushi/SettingsActivity.kt:196-205` — drop the
+  click listeners for `manageHostsButton` and `quickAddHostButton`.
+- `app/src/main/res/layout/page_settings_ssh.xml` — delete `quickAddHostButton`
+  (lines 194-202) and `manageHostsButton` (lines 216-224). Keep the summary
+  card and `quickGenerateKeyButton`.
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt` — no edits required;
+  the connect-button label inherits the kind suffix from
+  `displayTarget()` (delivered in Branch 2).
+
+**Verify:**
+
+- Manual click-path on a real device (run for both an SSH host and the
+  synthetic Local host): tap the host in `HostsActivity` → terminal opens
+  *connected*, no detour through `MainActivity`.
+- Connect-button label shows the kind suffix
+  (`"End session: <alias> · ssh|local"`).
+- Settings → SSH no longer has Manage Hosts / Quick Add Host buttons; the
+  summary card still renders host/auth/Gemini/Drive lines.
+- Save a brand new SSH host via `HostEditActivity` while a different host is
+  already active → confirm the active host did **not** silently change.
+- `./scripts/run-device-qa-suite.sh` clean.
+
+---
+
+## Cross-branch checks
+
+- SonarQube run on each branch before merge.
+- A release is cut on `main` after each branch lands (per the team's
+  ship-fast convention; do not batch).
+- `./scripts/run-device-qa-suite.sh` is the gate for every branch.
+- Persisted-data backwards compatibility is verified once during Branch 2
+  (the schema change) and re-verified on Branch 3 (no schema change, but
+  the editor now persists hosts under different conditions).
+
+## Renaissance hand-off
+
+`ConversationManager`, `PlayRunner`, and `PersonaClient` deliberately keep
+typing on `SshClient` through this work. The renaissance moves them onto
+`TerminalBackend`, decides what `execCommand`/`sftpUpload` look like for the
+local backend (probably `Runtime.exec` and a no-op respectively), and defines
+the plans-vs-results observability story that the user has flagged as the
+real reason for the Gemini overhaul. None of that belongs in this roadmap.

--- a/docs/concepts/HOST_KIND.md
+++ b/docs/concepts/HOST_KIND.md
@@ -1,0 +1,159 @@
+# Concept: HostKind
+
+A discriminator on `SshConnectionConfig` so that a local-shell session can be
+listed, selected, and persisted just like any other host. The user picks
+"Local shell" from `HostsActivity` and gets a terminal — no special-case
+screen, no separate flow.
+
+Related: [`TERMINAL_BACKEND.md`](./TERMINAL_BACKEND.md),
+[`LOCAL_SHELL_PTY.md`](./LOCAL_SHELL_PTY.md),
+[`HOST_SELECTION_UX.md`](./HOST_SELECTION_UX.md),
+[`../ROADMAP_LOCAL_SHELL.md`](../ROADMAP_LOCAL_SHELL.md).
+
+## Why a discriminator on `SshConnectionConfig`
+
+The least disruptive shape. Today `SshSettings.getHosts()`, `HostAdapter`, and
+`HostEditActivity` all iterate `List<SshConnectionConfig>`
+(`SshSettings.kt:36-43`, `HostAdapter.kt:15`, `HostEditActivity.kt:14`). A
+parallel `LocalHostConfig` type would fork all three: two adapters, two
+persisted lists, two pickers in `HostEditActivity` (jump-server selector takes
+`SshConnectionConfig`).
+
+A single field on the existing class costs one branch in the activity that
+opens a session and a few field-visibility toggles in the editor. Everything
+else — list rendering, persistence, jump-server selection — keeps working.
+
+The class name `SshConnectionConfig` becomes mildly misleading once it can
+also describe a local shell. Renaming to `HostConfig` is a follow-up; this
+branch leaves the name alone to keep the diff focused.
+
+## The enum and field
+
+```kotlin
+enum class HostKind { SSH, LOCAL }
+
+data class SshConnectionConfig(
+    val kind: HostKind = HostKind.SSH,   // default preserves old persisted data
+    val id: String = java.util.UUID.randomUUID().toString(),
+    val alias: String = "",
+    val host: String,
+    val port: Int,
+    val username: String,
+    val password: String,
+    val authPreference: String? = SshAuthPreference.AUTO.value,
+    val privateKey: String? = null,
+    val jumpEnabled: Boolean = false,
+    val jumpHostId: String? = null,
+    val jumpHost: String = "",
+    val jumpPort: Int = 22,
+    val jumpUsername: String = "",
+    val jumpPassword: String = "",
+)
+```
+
+When `kind == LOCAL`, the SSH-only fields (`host`, `port`, `username`, etc.)
+are stored as empty/zero and ignored at runtime by the local backend.
+
+## Persistence — no schema bump needed
+
+`SshSettings` uses Moshi with `KotlinJsonAdapterFactory`
+(`SshSettings.kt:10`). Kotlin defaults are honoured: a JSON document missing
+the `kind` field deserialises with `kind = HostKind.SSH`, which is exactly the
+historical behaviour. Enum values serialise by name (`"SSH"`, `"LOCAL"`).
+
+**Verification path:** install the new build over an older one with persisted
+SSH hosts; open `HostsActivity`; confirm those hosts show up unchanged. For
+deeper verification, dump the prefs file:
+
+```
+adb shell run-as net.hlan.sushi cat files/...   # path varies by SecurePrefs
+```
+
+and confirm the new `kind` field is present after the next save and
+old-format JSON without it still loads.
+
+## Synthetic Local host
+
+A single LOCAL-kind host is seeded on first launch. New method on
+`SshSettings`:
+
+```kotlin
+fun seedLocalHostIfMissing() {
+    if (getHosts().any { it.kind == HostKind.LOCAL }) return
+    val local = SshConnectionConfig(
+        kind = HostKind.LOCAL,
+        alias = context.getString(R.string.local_shell_default_alias), // "Local shell"
+        host = "", port = 0, username = "", password = "",
+    )
+    saveHost(local)
+}
+```
+
+`SshSettings(context)` already takes a `Context` (`SshSettings.kt:8`) for
+`SecurePrefs.get()`; store it as a field so `seedLocalHostIfMissing` can
+resolve the string resource.
+
+Called from `SushiApplication.onCreate()` so the host exists before any
+activity runs. **Not** from `SettingsActivity.migrateOldSettingsIfNeeded()`
+(`SshSettings.kt:115-141`), which only fires when settings are opened — wrong
+hook for first-launch seeding.
+
+The synthetic host:
+- is editable for `alias` only (the user can rename it);
+- cannot be deleted (the **Delete** button is hidden in `HostEditActivity`
+  when `kind == LOCAL`);
+- never has `kind` reassigned by the editor.
+
+## `displayTarget()` extension
+
+`SshConnectionConfig.displayTarget()` (`SshClient.kt:48-52`) is reused widely
+— connect-button label, terminal status row, "connected to" log line, and
+host-pickers across `ShareActivity` and `HostEditActivity`. Extending it to
+include a kind suffix (`"Production · ssh"`, `"Local · local"`) gives every
+caller the right label for free.
+
+```kotlin
+fun displayTarget(): String {
+    val core = if (kind == HostKind.LOCAL) {
+        alias.ifBlank { "Local shell" }
+    } else if (alias.isNotBlank()) {
+        "$alias ($username@$host:$port)"
+    } else {
+        "$username@$host:$port"
+    }
+    val kindLabel = if (kind == HostKind.LOCAL) "local" else "ssh"
+    return "$core · $kindLabel"
+}
+```
+
+This is what makes [`HOST_SELECTION_UX.md`](./HOST_SELECTION_UX.md)'s "active
+host visible in `TerminalActivity`" requirement a no-op: the existing
+connect-button label automatically reads `"End session: Production · ssh"` /
+`"Start session: Local shell · local"`.
+
+## HostEditActivity field visibility
+
+`HostEditActivity.kt:65-83, 85-135` already gates fields by
+`isEditMode`. Add a parallel gating by `kind`:
+
+- When `kind == LOCAL`: hide `sshHostInput`, `sshPortInput`,
+  `sshUsernameInput`, `sshPasswordInput`, `authPreferenceInput`,
+  `jumpEnabledSwitch`, the entire jump section. Show only `hostAliasInput`.
+- `saveHost()` (line 85): when `kind == LOCAL`, skip the host/username
+  validation and persist with empty SSH fields.
+- For new hosts (no `EXTRA_HOST_ID`), the editor only creates SSH hosts. Local
+  is exclusively the synthetic instance — no UI for the user to add a second
+  one.
+
+## Critical files
+
+- `app/src/main/java/net/hlan/sushi/SshClient.kt` (lines 14-53: enum + field
+  + `displayTarget()` extension)
+- `app/src/main/java/net/hlan/sushi/SshSettings.kt` (line 8: store context;
+  add `seedLocalHostIfMissing()`; line 10: Moshi factory unchanged)
+- `app/src/main/java/net/hlan/sushi/SushiApplication.kt` (call seed in
+  `onCreate`)
+- `app/src/main/java/net/hlan/sushi/HostEditActivity.kt` (lines 29-38, 65-83,
+  85-135: kind-aware visibility and validation; hide delete for LOCAL)
+- `app/src/main/res/values/strings.xml` (new
+  `local_shell_default_alias`)

--- a/docs/concepts/HOST_SELECTION_UX.md
+++ b/docs/concepts/HOST_SELECTION_UX.md
@@ -1,0 +1,150 @@
+# Concept: Host-selection UX
+
+Four targeted fixes to remove the friction the user described as "bizarre and
+overly labored." This is **not** a home-screen redesign — it cuts the most
+expensive taps and removes one source of hidden state changes. The broader
+in-terminal switcher and home-screen overhaul are deferred.
+
+Related: [`TERMINAL_BACKEND.md`](./TERMINAL_BACKEND.md),
+[`HOST_KIND.md`](./HOST_KIND.md),
+[`LOCAL_SHELL_PTY.md`](./LOCAL_SHELL_PTY.md),
+[`../ROADMAP_LOCAL_SHELL.md`](../ROADMAP_LOCAL_SHELL.md). See also the prior
+audit at [`../FLOW_IMPROVEMENTS.md`](../FLOW_IMPROVEMENTS.md).
+
+## Friction today
+
+To open a session with a known host, the user does roughly the following:
+
+1. `MainActivity` → tap **Configure host** (or **Settings → SSH → Manage
+   Hosts**).
+2. `HostsActivity` → tap a host. The activity calls
+   `setActiveHostId()` and `finish()`s. **Nothing else happens.** The user
+   is back at `MainActivity`.
+3. `MainActivity` → tap **Start session** (or **Return to terminal**).
+4. `TerminalActivity` → tap **Start session** (auto-connect already runs in
+   most cases, but in some paths the user lands disconnected and must tap).
+
+That is two activities and 4–6 taps to reach a connected shell on a host the
+user has used many times. The split between *picking* and *opening* is an
+artefact, not a feature — pick is implicit in the user's intent to open.
+
+A second source of friction: saving a brand new host in `HostEditActivity`
+silently flips the active host to the new one (`HostEditActivity.kt:128-131`)
+if no host was active before. There is no toast or banner, the user just
+discovers later that their session is going somewhere unexpected.
+
+A third: `SettingsActivity` → SSH tab has its own **Manage Hosts** and **Quick
+Add Host** buttons (`page_settings_ssh.xml:194-224`,
+`SettingsActivity.kt:199-205`). They duplicate `HostsActivity`'s reason to
+exist and create two paths to the same screens. The summary card on the same
+tab is useful — it stays. The buttons go.
+
+## Fix 1 — One-tap connect from `HostsActivity`
+
+`HostsActivity.kt:20-31` `onHostClick` becomes:
+
+```kotlin
+adapter = HostAdapter(
+    onHostClick = { host ->
+        sshSettings.setActiveHostId(host.id)
+        startActivity(TerminalActivity.createIntent(this, autoConnect = true))
+        finish()
+    },
+    onEditClick = { host ->
+        startActivity(Intent(this, HostEditActivity::class.java).apply {
+            putExtra(HostEditActivity.EXTRA_HOST_ID, host.id)
+        })
+    },
+)
+```
+
+`TerminalActivity.createIntent(context, autoConnect)` already exists at
+`TerminalActivity.kt:323` and is already used by `MainActivity:111,115`.
+`EXTRA_AUTO_CONNECT` is wired at `TerminalActivity.kt:99-101`. **No
+`TerminalActivity` change is required for this fix.**
+
+Result: tapping a host opens a connected session. One tap, one screen.
+
+## Fix 2 — Active host visible in `TerminalActivity`
+
+`TerminalActivity.updateUi()` already reads `displayTarget()` for the
+connect-button label (`TerminalActivity.kt:270-277`). Once
+[`HOST_KIND.md`](./HOST_KIND.md)'s `displayTarget()` extension lands, the
+label automatically reads e.g. `"End session: Production · ssh"` /
+`"Start session: Local shell · local"`.
+
+That is enough to answer the "where am I about to connect / where am I
+connected" question. **Verify on device** before adding new widgets — it may
+already be enough. If not, the next step is a small status row above the
+output, fed by the same `displayTarget()` value; do not invent a new field.
+
+## Fix 3 — Drop silent first-host auto-select
+
+Delete `HostEditActivity.kt:128-131`:
+
+```kotlin
+// Auto-select if it's the first host or just created
+if (sshSettings.getActiveHostId() == null) {
+    sshSettings.setActiveHostId(config.id)
+}
+```
+
+After save, the user returns to `HostsActivity` (the editor's `finish()` at
+line 134). Activating the new host is now a one-tap action thanks to Fix 1,
+so there is no UX cost to making it explicit. The win is no hidden state
+changes.
+
+A first-time user sees the empty-state copy in `HostsActivity` once, taps
+**Add host**, fills in fields, taps **Save**, lands back in `HostsActivity`
+with the new host visible, taps it, and is in a session. Five taps total,
+zero of them surprising.
+
+## Fix 4 — Settings dedup
+
+`app/src/main/res/layout/page_settings_ssh.xml`:
+
+- Delete `quickAddHostButton` (lines 194-202).
+- Delete `manageHostsButton` (lines 216-224).
+- Keep `settingsSummaryCard` (lines 29-149) — the read-only host/auth/Gemini/
+  Drive summary stays; it answers "what's set up" without inviting
+  navigation.
+- Keep `quickGenerateKeyButton` and the `testConnectionButton` /
+  `copyConnectionDiagnosticsButton` cluster — those are SSH-tab-native, not
+  duplicates.
+
+`SettingsActivity.kt:196-205` (`setupSshPage`): delete the two click
+listeners for `pageBinding.manageHostsButton` and
+`pageBinding.quickAddHostButton`. Leave the rest of the function intact.
+
+Single entry point to host management is now `MainActivity`'s
+`configureHostButton` (`MainActivity.kt:118-125`). It opens `HostEditActivity`
+when the host list is empty (first-run) and `HostsActivity` otherwise — that
+heuristic is correct; keep it.
+
+## Out of scope (deferred)
+
+- **In-terminal host switcher** — the dropdown idea from
+  `FLOW_IMPROVEMENTS.md`. Worth doing later, but adds widgets and state to
+  `TerminalActivity` and is not required to remove the current pain.
+- **Jump-server-as-host-reference refactor** — the editor still mirrors jump
+  fields onto the dependent host. Cleaning that up is its own concept doc.
+- **Home-screen redesign** — beyond removing the duplicate Settings buttons,
+  `MainActivity`'s top section is unchanged.
+- **Active-host indicator in `MainActivity`** — `displayTarget()`'s kind
+  suffix could land here too, but `MainActivity` already shows the host name
+  on the **Return to terminal** button; deferring until users ask.
+
+## Critical files
+
+- `app/src/main/java/net/hlan/sushi/HostsActivity.kt` (lines 20-31: one-tap
+  connect)
+- `app/src/main/java/net/hlan/sushi/HostEditActivity.kt` (lines 128-131:
+  delete silent auto-select)
+- `app/src/main/java/net/hlan/sushi/SettingsActivity.kt` (lines 196-205:
+  drop button wiring)
+- `app/src/main/res/layout/page_settings_ssh.xml` (lines 194-202, 216-224:
+  delete buttons)
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt` (line 270:
+  inherits the kind suffix from `displayTarget()`)
+- `app/src/main/java/net/hlan/sushi/MainActivity.kt` (lines 118-125:
+  unchanged — single entry point for host management)

--- a/docs/concepts/LOCAL_SHELL_PTY.md
+++ b/docs/concepts/LOCAL_SHELL_PTY.md
@@ -1,0 +1,243 @@
+# Concept: Local-shell PTY
+
+The local-shell backend gives the user a real, full-featured shell on the
+Android device itself. Real means a PTY: `vi`, `top`, `less`, `nano`,
+`watch`, `ssh` from the device — all the things that need a controlling
+terminal — actually work.
+
+Related: [`TERMINAL_BACKEND.md`](./TERMINAL_BACKEND.md),
+[`HOST_KIND.md`](./HOST_KIND.md),
+[`HOST_SELECTION_UX.md`](./HOST_SELECTION_UX.md),
+[`../ROADMAP_LOCAL_SHELL.md`](../ROADMAP_LOCAL_SHELL.md).
+
+## Why not Termux's `terminal-emulator`
+
+Termux ships a battle-tested PTY + emulator library, but it is **GPLv3**.
+Linking it would require Sushi to relicense from Apache-style permissive to
+GPL — a bigger decision than this branch should make. The reuse argument is
+also weak: Sushi already renders with its own `TerminalView`, so it does not
+need the emulator part. It needs only a PTY allocator: ~100 lines of C.
+
+## Native lib `sushi-pty`
+
+A small JNI shim that wraps `forkpty(3)` and the four operations we need on
+the master fd. Lib name: `sushi-pty`, loaded via
+`System.loadLibrary("sushi-pty")` from `LocalShellBackend`.
+
+JNI surface (declared as `external` companion functions on
+`LocalShellBackend`):
+
+```
+nativeStart(cmd: String, argv: Array<String>, envp: Array<String>): Long
+    Returns an opaque handle (pointer to a malloc'd { master_fd, child_pid }
+    struct, cast to jlong). 0 on failure.
+
+nativeRead(handle: Long, buf: ByteArray): Int
+    Blocking read from master_fd. Returns bytes read, or -1 on EOF/EIO so the
+    Kotlin reader thread exits cleanly.
+
+nativeWrite(handle: Long, data: ByteArray): Int
+    write() loop on master_fd; handles EINTR. Returns bytes written, or -1.
+
+nativeResize(handle: Long, col: Int, row: Int, widthPx: Int, heightPx: Int)
+    ioctl(master_fd, TIOCSWINSZ, &winsize).
+
+nativeClose(handle: Long)
+    kill(child_pid, SIGHUP); waitpid(child_pid, NULL, 0); close(master_fd);
+    free struct.
+```
+
+C implementation notes (in `app/src/main/cpp/sushi-pty.c`):
+
+- `forkpty(&master_fd, NULL, NULL, NULL)` — creates the master/slave pair,
+  forks, calls `setsid()` in the child, and assigns the slave as the
+  controlling terminal.
+- Set `FD_CLOEXEC` on `master_fd` so it does not leak into other forks.
+- In the child, walk `envp` and `setenv()` each `KEY=VALUE` entry, then
+  `execvp(cmd, argv)`. On failure write a marker to fd 2 and `_exit(127)`.
+- `nativeRead`/`nativeWrite` loop on `EINTR`. Treat `EIO` as EOF (Linux
+  reports `EIO` on master fd when the slave has been closed by the child
+  exiting).
+- `nativeClose` is idempotent and safe to call from a finalizer-ish path.
+- Track exactly one allocation per session in the handle struct so `free()`
+  is straightforward.
+
+The whole file is small enough that it does not warrant being split. Link
+only against `log` (optional, for `__android_log_print` warnings — fine to
+omit).
+
+## Kotlin side: `LocalShellBackend`
+
+Mirrors the threading style of `SshClient.startShellReader()`
+(`SshClient.kt:447-468`) so a reader of either backend feels familiar:
+
+- A daemon `Thread` named `LocalShellReader` calls `nativeRead` in a loop,
+  invokes `onLine` (or the streamed callback) with the decoded bytes, and
+  exits when `nativeRead` returns -1.
+- On exit, calls the `onConnectionClosed` callback so `TerminalActivity`'s
+  monitor handler reacts the same way it does to an SSH disconnect.
+- Writes use `Thread { ... }.start()` per the existing convention in
+  `TerminalActivity.sendRaw` (line 232).
+- `runCatching` around all native calls in cleanup paths.
+
+```kotlin
+class LocalShellBackend(private val context: Context) : TerminalBackend {
+    private var nativeHandle: Long = 0L
+    private var readerThread: Thread? = null
+
+    override fun connect(
+        onLine: (String) -> Unit,
+        streamMode: Boolean,
+        onConnectionClosed: (() -> Unit)?,
+    ): SshConnectResult {
+        val shell = System.getenv("SHELL").takeUnless { it.isNullOrBlank() }
+            ?: "/system/bin/sh"
+        val handle = nativeStart(shell, arrayOf(shell, "-i"), defaultEnv())
+        if (handle == 0L) {
+            return SshConnectResult(false, "PTY allocation failed")
+        }
+        nativeHandle = handle
+        startReader(onLine, streamMode, onConnectionClosed)
+        return SshConnectResult(true, "Connected to local shell")
+    }
+
+    override fun isConnected(): Boolean = nativeHandle != 0L
+    override fun sendText(text: String): SshCommandResult { /* nativeWrite */ }
+    override fun sendCommand(command: String): SshCommandResult {
+        val payload = if (command.endsWith("\n")) command else "$command\n"
+        return sendText(payload)
+    }
+    override fun sendCtrlC() { /* nativeWrite byte 3 */ }
+    override fun sendCtrlD() { /* nativeWrite byte 4 */ }
+    override fun resizePty(col: Int, row: Int, wp: Int, hp: Int) {
+        if (nativeHandle != 0L) nativeResize(nativeHandle, col, row, wp, hp)
+    }
+    override fun disconnect() {
+        val h = nativeHandle; nativeHandle = 0L
+        if (h != 0L) runCatching { nativeClose(h) }
+        readerThread = null
+    }
+
+    private fun defaultEnv(): Array<String> = listOf(
+        "HOME=${System.getenv("HOME") ?: context.filesDir.absolutePath}",
+        "PATH=${System.getenv("PATH") ?: "/system/bin:/system/xbin"}",
+        "ANDROID_DATA=${System.getenv("ANDROID_DATA") ?: "/data"}",
+        "ANDROID_ROOT=${System.getenv("ANDROID_ROOT") ?: "/system"}",
+        "TMPDIR=${context.cacheDir.absolutePath}",
+        "TERM=xterm-256color",
+    ).toTypedArray()
+
+    companion object {
+        init { System.loadLibrary("sushi-pty") }
+        @JvmStatic external fun nativeStart(cmd: String, argv: Array<String>, envp: Array<String>): Long
+        @JvmStatic external fun nativeRead(handle: Long, buf: ByteArray): Int
+        @JvmStatic external fun nativeWrite(handle: Long, data: ByteArray): Int
+        @JvmStatic external fun nativeResize(handle: Long, col: Int, row: Int, wp: Int, hp: Int)
+        @JvmStatic external fun nativeClose(handle: Long)
+    }
+}
+```
+
+The `defaultEnv` allowlist is deliberately small: enough to feel like a real
+shell, not so much that we leak surprising state from the app process. Pass
+`Context` through so `cacheDir` and `filesDir` are reachable.
+
+## Gradle wiring
+
+`app/build.gradle.kts`:
+
+```kotlin
+android {
+    // ...
+    ndkVersion = "27.0.12077973"   // pin to a current stable; verify in CI
+    defaultConfig {
+        // ...
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+        }
+        externalNativeBuild {
+            cmake { /* nothing required here today */ }
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+}
+```
+
+ABIs: `arm64-v8a` and `armeabi-v7a` cover real devices; `x86_64` is included
+so emulator-based instrumented tests work (`./gradlew
+connectedDebugAndroidTest` on a `x86_64` emulator).
+
+`CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.22.1)
+project(sushi-pty C)
+
+add_library(sushi-pty SHARED sushi-pty.c)
+target_link_libraries(sushi-pty log)
+```
+
+## A note on `minSdk`
+
+Actual `minSdk` is **26** per `app/build.gradle.kts:25`. `CLAUDE.md` says
+"min SDK 24" but `CLAUDE.md` is stale; the Gradle file is the source of
+truth. Do **not** lower `minSdk` for this work. minSdk 26 is fine for
+`forkpty` — the NDK provides it on all supported ABIs.
+
+## ProGuard
+
+`app/proguard-rules.pro` additions:
+
+```
+# Native methods must keep their JNI-resolvable names.
+-keepclasseswithmembernames class * { native <methods>; }
+
+# LocalShellBackend's name is referenced by the JNI symbol naming convention
+# (Java_net_hlan_sushi_LocalShellBackend_native*). Keep the class to be safe.
+-keep class net.hlan.sushi.LocalShellBackend { *; }
+```
+
+The release build is minified. Verify with `./gradlew assembleRelease` then
+install on device that `libsushi-pty.so` loads and the synthetic Local host
+opens cleanly.
+
+## TerminalActivity branching
+
+`TerminalActivity.kt:110-127` (`connectTerminal()`) gains a single switch:
+
+```kotlin
+val config = sshSettings.getConfigOrNull() ?: ...
+val newBackend: TerminalBackend = when (config.kind) {
+    HostKind.SSH -> SshClient(config)
+    HostKind.LOCAL -> LocalShellBackend(applicationContext)
+}
+```
+
+The retry loop at `TerminalActivity.kt:131-145` only makes sense for network
+failures. Guard it:
+
+```kotlin
+if (!result.success && config.kind == HostKind.SSH) {
+    // existing retry block
+}
+```
+
+`connectWithClient(config)` (line 290) becomes `connectWith(backend, config)`
+and stops constructing `SshClient` itself — its caller already picked the
+backend.
+
+## Critical files
+
+- `app/src/main/cpp/sushi-pty.c` (new)
+- `app/src/main/cpp/CMakeLists.txt` (new)
+- `app/src/main/java/net/hlan/sushi/LocalShellBackend.kt` (new)
+- `app/build.gradle.kts` (NDK + cmake + abiFilters)
+- `app/proguard-rules.pro` (keep native methods + `LocalShellBackend`)
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt` (lines 110-127:
+  kind branching; lines 131-145: SSH-only retry guard; lines 290-308:
+  helper signature)

--- a/docs/concepts/TERMINAL_BACKEND.md
+++ b/docs/concepts/TERMINAL_BACKEND.md
@@ -1,0 +1,130 @@
+# Concept: TerminalBackend
+
+A small Kotlin interface that captures the contract `TerminalActivity` needs
+from any interactive shell session — SSH today, local-shell tomorrow.
+Everything else in the local-shell work hangs off this abstraction.
+
+Related: [`HOST_KIND.md`](./HOST_KIND.md),
+[`LOCAL_SHELL_PTY.md`](./LOCAL_SHELL_PTY.md),
+[`HOST_SELECTION_UX.md`](./HOST_SELECTION_UX.md),
+[`../ROADMAP_LOCAL_SHELL.md`](../ROADMAP_LOCAL_SHELL.md).
+
+## Why an abstraction
+
+`TerminalActivity` is wired directly to `SshClient` today
+(`TerminalActivity.kt:29, 60, 73-86, 92-94, 170, 233, 290-308`). Adding a
+second backend would force one of two unattractive shapes:
+
+- **Fork the activity** — a `LocalTerminalActivity` that duplicates the
+  retry loop, the resize forwarding, the input dedup, and the connection
+  monitor. The bug-fix-once-per-place tax is real and immediate.
+- **Type-check at every call site** — `if (sshClient != null) … else if
+  (localBackend != null) …`. Every method gains a branch.
+
+A thin interface is cheaper than either. `TerminalActivity` keeps one field,
+one set of call sites, and one retry/monitor pipeline. The two backends differ
+only in their constructor and in the body of `connect()`.
+
+## The interface
+
+New file `app/src/main/java/net/hlan/sushi/TerminalBackend.kt`. Captures only
+the methods `TerminalActivity` actually calls — no aspirational surface.
+
+```kotlin
+package net.hlan.sushi
+
+interface TerminalBackend {
+    fun connect(
+        onLine: (String) -> Unit,
+        streamMode: Boolean = false,
+        onConnectionClosed: (() -> Unit)? = null,
+    ): SshConnectResult
+    fun isConnected(): Boolean
+    fun sendText(text: String): SshCommandResult
+    fun sendCommand(command: String): SshCommandResult
+    fun sendCtrlC()
+    fun sendCtrlD()
+    fun resizePty(col: Int, row: Int, widthPx: Int, heightPx: Int)
+    fun disconnect()
+}
+```
+
+The signatures are copied verbatim from `SshClient` so making `SshClient`
+implement the interface is a one-line change (`SshClient.kt:71` gains
+`: TerminalBackend`). No other body changes are needed in `SshClient`.
+
+`SshConnectResult` and `SshCommandResult` already exist at `SshClient.kt:55-64`
+and are reused as the interface return types. Renaming them to
+`TerminalConnectResult` / `TerminalCommandResult` is a follow-up that touches
+every call site and is not worth bundling into this branch.
+
+## What stays out of the interface
+
+`execCommand()` and `sftpUpload()` are SSH-specific:
+
+- `execCommand()` uses a JSch exec channel
+  (`SshClient.kt:275-352`) — there is no analogue in a local PTY session, where
+  you would just use the shell or `Runtime.exec` directly. Used by
+  `ConversationManager` (`ConversationManager.kt:191`) and
+  `SettingsActivity`'s test-connection button (`SettingsActivity.kt:567`).
+- `sftpUpload()` opens an SFTP channel — used by `ShareActivity` for
+  share-to-host file uploads.
+
+Both stay on `SshClient` only. The interface is the **PTY contract**, nothing
+more.
+
+## Holder rework
+
+`SshConnectionHolder` (today: holds an `SshClient` and `SshConnectionConfig`)
+becomes a session holder for any backend, but it keeps a parallel reference to
+the concrete `SshClient` so the conversation path keeps working without
+forcing `ConversationManager` onto the interface (the renaissance defers
+that).
+
+```kotlin
+object SshConnectionHolder {
+    private var activeBackend: TerminalBackend? = null
+    private var activeSshClient: SshClient? = null   // non-null only when SSH
+    private var activeHostConfig: SshConnectionConfig? = null
+    // listeners unchanged
+
+    fun setActiveConnection(backend: TerminalBackend, config: SshConnectionConfig) {
+        activeBackend = backend
+        activeSshClient = backend as? SshClient
+        activeHostConfig = config
+        notifyConnected()
+    }
+    fun getActiveBackend(): TerminalBackend? = activeBackend
+    fun getActiveSshClient(): SshClient? = activeSshClient
+    fun getActiveConfig(): SshConnectionConfig? = activeHostConfig
+    fun isConnected(): Boolean = activeBackend?.isConnected() == true
+    // clearActiveConnection() nulls all three
+}
+```
+
+`MainActivity.kt:878` (the only conversation-init call site) switches from
+`getActiveClient()` to `getActiveSshClient()`. When the active host is LOCAL,
+the call returns `null` and `initializeConversation()` no-ops — that matches
+the "Gemini deferred" decision.
+
+Renaming the object to `TerminalSessionHolder` is cosmetic and is left for a
+follow-up to keep this diff surgical.
+
+## Renaissance hand-off
+
+`ConversationManager`, `PlayRunner`, and `PersonaClient` deliberately stay
+typed on `SshClient` through this work. The renaissance is when they move onto
+`TerminalBackend` and define the plans-vs-results observability story. This
+branch establishes the seam, not the migration.
+
+## Critical files
+
+- `app/src/main/java/net/hlan/sushi/TerminalBackend.kt` (new)
+- `app/src/main/java/net/hlan/sushi/SshClient.kt` (line 71: implement
+  interface; lines 55-64: shared result types)
+- `app/src/main/java/net/hlan/sushi/SshConnectionHolder.kt` (full rewrite —
+  small file)
+- `app/src/main/java/net/hlan/sushi/TerminalActivity.kt` (line 29 type, line
+  290 helper signature)
+- `app/src/main/java/net/hlan/sushi/MainActivity.kt` (line 878:
+  `getActiveSshClient`)

--- a/docs/plans/local-shell-rework-plan.md
+++ b/docs/plans/local-shell-rework-plan.md
@@ -1,0 +1,301 @@
+# Local-shell terminal + host-selection rework — docs & roadmap
+
+## Context
+
+Sushi is currently SSH-only. We want a **local-shell terminal** on the Android
+device with a real PTY (so `vi`/`top`/`less` work), surfaced as just another
+host in the existing host list. While auditing the wiring it became obvious the
+host-selection UX is doing too much work: connecting to a known host takes 6–8
+taps because *picking* a host (`HostsActivity`) and *opening a session*
+(`MainActivity` → `TerminalActivity` → tap **Start session**) are split across
+three screens.
+
+**Plays and Gemini are explicitly out of scope** — the user has flagged them
+for a future "renaissance". This pass establishes the foundation only.
+
+This planning step produces **documentation only** — no source-code changes
+yet. The deliverable is:
+
+1. Four concept docs under `docs/concepts/` capturing the *what* and *why*
+2. One roadmap doc under `docs/` capturing the *how* and *when* (phased
+   implementation)
+
+The existing `docs/` layout (e.g. `docs/USER_STORIES.md`,
+`docs/UX_FLOWS.md`, `docs/FLOW_IMPROVEMENTS.md`) sets the convention: per-topic
+markdown files at the docs root. We add a `docs/concepts/` subdirectory because
+we are introducing four genuinely separate concepts that benefit from being
+linkable individually.
+
+## Deliverable layout
+
+```
+docs/
+├── concepts/
+│   ├── TERMINAL_BACKEND.md      ← abstraction contract
+│   ├── HOST_KIND.md             ← SSH/LOCAL discriminator + synthetic host
+│   ├── LOCAL_SHELL_PTY.md       ← JNI shim + native lib design
+│   └── HOST_SELECTION_UX.md     ← one-tap connect, dedup, active-host display
+└── ROADMAP_LOCAL_SHELL.md       ← phased implementation plan
+```
+
+Each concept doc is self-contained (problem, design, alternatives considered,
+critical files referenced). The roadmap depends on all four — it sequences
+their implementation across three branches and lists the verify-before-merge
+steps for each.
+
+---
+
+## Shape of the change (preview — full detail in concept docs)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 1 — TerminalBackend abstraction (no user-visible change)  │
+│   SshClient ──implements──▶ TerminalBackend                      │
+│   SshConnectionHolder ─▶ TerminalBackend  (+ legacy SshClient?)  │
+│   ConversationManager: unchanged (renaissance defers it)         │
+└──────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 2 — Local backend + JNI PTY                               │
+│   HostKind {SSH, LOCAL} on SshConnectionConfig (default SSH;     │
+│       Moshi Kotlin defaults handle old persisted JSON)           │
+│   LocalShellBackend ──JNI──▶ libsushi-pty.so (forkpty,           │
+│                              ~100 LOC C, no GPL dependency)      │
+│   Synthetic Local host seeded on first launch                    │
+└──────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Branch 3 — Host-selection UX                                     │
+│   HostsActivity row tap ──▶ TerminalActivity.createIntent(       │
+│                                  autoConnect = true)             │
+│   Drop silent first-host auto-select; dedup Settings buttons     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## File-by-file: what to write
+
+### `docs/concepts/TERMINAL_BACKEND.md`
+
+**Purpose:** define the PTY contract that both SSH and local sessions
+implement. Everything else in this work hangs off this abstraction.
+
+**Sections:**
+- *Why an abstraction* — `TerminalActivity` today is wired directly to
+  `SshClient` (`TerminalActivity.kt:29, 60, 73-86, 92-94, 170, 233, 290-308`).
+  A second backend would either fork the activity or hide behind type checks.
+  An interface is cheaper.
+- *The interface* (verbatim Kotlin, captures only the methods
+  `TerminalActivity` actually calls — `connect`, `isConnected`, `sendText`,
+  `sendCommand`, `sendCtrlC`, `sendCtrlD`, `resizePty`, `disconnect`).
+- *What stays out of the interface* — `execCommand()` and `sftpUpload()` are
+  SSH-specific and used by `ConversationManager` (`ConversationManager.kt:191`),
+  `SettingsActivity`'s test button (`SettingsActivity.kt:567`), and
+  `ShareActivity`. They remain on `SshClient` only.
+- *Holder rework* — `SshConnectionHolder` keeps both
+  `getActiveBackend(): TerminalBackend?` and `getActiveSshClient(): SshClient?`
+  so the conversation path keeps working without forcing
+  `ConversationManager` onto the interface (renaissance defers it).
+- *Reuse* — keep existing `SshConnectResult` and `SshCommandResult`
+  (`SshClient.kt:55-64`) as the interface return types; renaming is a follow-up.
+- *Critical files referenced:* `SshClient.kt:71`, `SshConnectionHolder.kt`,
+  `TerminalActivity.kt:29,290`, `MainActivity.kt:878`.
+
+### `docs/concepts/HOST_KIND.md`
+
+**Purpose:** add a discriminator so a local shell appears as just another host.
+
+**Sections:**
+- *Why a discriminator on `SshConnectionConfig`* (Option A) — least disruptive;
+  `SshSettings`, `HostAdapter`, `HostEditActivity` already iterate
+  `List<SshConnectionConfig>`. A parallel `LocalHostConfig` would fork all
+  three.
+- *The enum and field*:
+  ```kotlin
+  enum class HostKind { SSH, LOCAL }
+  data class SshConnectionConfig(
+      val kind: HostKind = HostKind.SSH,   // default preserves old data
+      // ...
+  )
+  ```
+- *Persistence migration* — Moshi's `KotlinJsonAdapterFactory`
+  (`SshSettings.kt:10`) honours Kotlin defaults; old persisted JSON
+  deserialises with `kind = SSH` automatically. **No schema bump.**
+- *Synthetic Local host* — seeded on first app launch via new
+  `SshSettings.seedLocalHostIfMissing()`, called from
+  `SushiApplication.onCreate()` (not from `SettingsActivity`'s existing
+  `migrateOldSettingsIfNeeded()` — that only runs when settings are opened).
+  Synthetic host alias defaults to `R.string.local_shell_default_alias`
+  ("Local shell"), is editable for alias only, and cannot be deleted.
+- *`displayTarget()` extension* — append a kind suffix so the existing
+  connect-button label, terminal status row, and "connected to" log line all
+  gain the indicator without new wiring.
+- *HostEditActivity field visibility* — when `kind == LOCAL`, hide
+  host/port/username/password/auth/jump fields; show only alias.
+- *Critical files referenced:* `SshClient.kt:14-53`, `SshSettings.kt:10,91-141`,
+  `HostEditActivity.kt:65-83,85-135`, `SushiApplication.kt`,
+  `app/src/main/res/values/strings.xml`.
+
+### `docs/concepts/LOCAL_SHELL_PTY.md`
+
+**Purpose:** specify the local backend and the native PTY shim.
+
+**Sections:**
+- *Why not Termux's `terminal-emulator`* — GPLv3, would force Sushi to GPL.
+  Sushi already has its own `TerminalView`; it only needs a PTY allocator,
+  which is ~100 LOC of C.
+- *Native lib `sushi-pty`* — JNI surface:
+  ```
+  nativeStart(cmd: String, argv: String[], envp: String[]): Long  // master fd handle
+  nativeWrite(handle: Long, data: ByteArray): Int
+  nativeRead(handle: Long, buf: ByteArray): Int                   // blocking
+  nativeResize(handle: Long, col, row, wp, hp)
+  nativeClose(handle: Long)
+  ```
+  Implementation notes: `forkpty(&master_fd, NULL, NULL, NULL)`,
+  `FD_CLOEXEC` on master, `setenv()` from envp in child, `execvp()`,
+  `_exit(127)` on exec failure, `ioctl(TIOCSWINSZ)` for resize, `kill(SIGHUP)
+  + waitpid()` on close. Loop on EINTR for read/write.
+- *Kotlin side* — `LocalShellBackend.kt` mirrors the threading style of
+  `SshClient.startShellReader()` (`SshClient.kt:447-468`): daemon `Thread`
+  named `LocalShellReader`, blocking `nativeRead`, `runCatching` cleanup on
+  disconnect. Writes use `Thread { ... }.start()` per existing convention in
+  `TerminalActivity.sendRaw` (line 232).
+- *Default shell* — `System.getenv("SHELL") ?: "/system/bin/sh"`. Args
+  `["-i"]`. Env allowlist: `HOME`, `PATH`, `ANDROID_DATA`, `ANDROID_ROOT`,
+  `TMPDIR=context.cacheDir.absolutePath`, `TERM=xterm-256color`.
+- *Gradle wiring* — `externalNativeBuild` with CMake; `ndkVersion` pinned;
+  `abiFilters = arm64-v8a, armeabi-v7a, x86_64` (x86_64 included for
+  emulator-based instrumented tests).
+- *Note on minSdk* — actual `minSdk = 26` per `app/build.gradle.kts:25`;
+  CLAUDE.md saying "min SDK 24" is stale. minSdk 26 is fine for `forkpty` (NDK
+  provides it).
+- *ProGuard* — `-keepclasseswithmembernames class * { native <methods>; }` and
+  `-keep class net.hlan.sushi.LocalShellBackend { *; }`.
+- *TerminalActivity branching* — `connectTerminal()` selects backend by
+  `config.kind`; SSH-only retry logic guarded by
+  `if (config.kind == HostKind.SSH)`.
+- *Critical files referenced:* `app/src/main/cpp/sushi-pty.c` (new),
+  `app/src/main/cpp/CMakeLists.txt` (new),
+  `app/src/main/java/net/hlan/sushi/LocalShellBackend.kt` (new),
+  `app/build.gradle.kts`, `app/proguard-rules.pro`, `TerminalActivity.kt:110-127,290-308`.
+
+### `docs/concepts/HOST_SELECTION_UX.md`
+
+**Purpose:** capture the four targeted UX fixes (no full redesign).
+
+**Sections:**
+- *Friction today* (cite `FLOW_IMPROVEMENTS.md` for prior analysis): tapping a
+  host in `HostsActivity` only marks it active and finishes; user must then
+  navigate to `TerminalActivity` and tap **Start session**. 6–8 taps to
+  connect.
+- *Fix 1: One-tap connect* — `HostsActivity.kt:20-31` `onHostClick` now calls
+  `setActiveHostId()` + `startActivity(TerminalActivity.createIntent(this,
+  autoConnect = true))` + `finish()`. The `createIntent(autoConnect)` factory
+  already exists at `TerminalActivity.kt:323`; no `TerminalActivity` change
+  needed.
+- *Fix 2: Active host visible in TerminalActivity* — `updateUi()` already
+  reads `displayTarget()` for the connect-button label
+  (`TerminalActivity.kt:270`). Once Branch 2 extends `displayTarget()` with the
+  kind suffix, the label automatically shows e.g. "End session: Production ·
+  ssh". Verify on device whether more is needed before adding new widgets.
+- *Fix 3: Drop silent first-host auto-select* — delete
+  `HostEditActivity.kt:128-131`. After save, user returns to `HostsActivity`
+  and explicitly taps to activate-and-connect (now one tap thanks to Fix 1).
+- *Fix 4: Settings dedup* — drop `manageHostsButton` and `quickAddHostButton`
+  from `page_settings_ssh.xml` (lines 194-202, 216-224) and their click
+  listeners in `SettingsActivity.kt:199-205`. Keep the read-only summary card
+  and `quickGenerateKeyButton`. `MainActivity`'s `configureHostButton` remains
+  the single entry point to host management.
+- *Out of scope (deferred):* in-terminal host switcher, jump-server-as-host-
+  reference refactor, home-screen redesign beyond the four bullets above.
+- *Critical files referenced:* `HostsActivity.kt:20-31`,
+  `HostEditActivity.kt:128-131`, `SettingsActivity.kt:196-205`,
+  `app/src/main/res/layout/page_settings_ssh.xml:194-224`,
+  `TerminalActivity.kt:323`.
+
+### `docs/ROADMAP_LOCAL_SHELL.md`
+
+**Purpose:** sequence the implementation across three branches with explicit
+verify steps and a single-source-of-truth dependency graph.
+
+**Sections:**
+- *Goal* — one paragraph: ship local-shell terminal + reduce
+  taps-to-connection. Out of scope: PlayRunner/Gemini wiring against local
+  backend.
+- *Concepts referenced* — bullet links to the four `docs/concepts/*.md` files,
+  one line each summarising what they define.
+- *Dependency graph* — the three-block diagram from this plan; explains why
+  the branches are sequential (Branch 2 needs the interface from Branch 1;
+  Branch 3 needs `displayTarget()`'s kind suffix from Branch 2 for the status
+  label, but its other fixes are independent and could ship sooner if
+  desired).
+- *Branch 1 — TerminalBackend abstraction* — list of edits with file paths
+  and line ranges:
+  - new file `TerminalBackend.kt`
+  - `SshClient.kt:71` add `: TerminalBackend`
+  - `SshConnectionHolder.kt` add backend/sshClient fields and accessors
+  - `TerminalActivity.kt:29,290` change types
+  - `MainActivity.kt:878` switch to `getActiveSshClient()`
+  - **Verify:** `./gradlew testDebugUnitTest` + `./gradlew lint` +
+    `./scripts/install-wifi-debug.sh` then manual SSH session.
+- *Branch 2 — Local backend* — list of edits with file paths:
+  - `SshClient.kt` add `HostKind` + `kind` field + extend `displayTarget()`
+  - new files `LocalShellBackend.kt`, `cpp/sushi-pty.c`, `cpp/CMakeLists.txt`
+  - `app/build.gradle.kts` NDK + cmake + abiFilters
+  - `app/proguard-rules.pro` keep native methods + LocalShellBackend
+  - `SshSettings.kt` `seedLocalHostIfMissing()`; `SushiApplication.kt` calls it
+  - `TerminalActivity.kt:110-127` kind branching
+  - `HostEditActivity.kt` field-visibility toggle by kind
+  - `app/src/main/res/values/strings.xml` new strings
+  - **Verify:** new `LocalShellBackendTest`; instrumented test opening
+    Local host, running `ls /` and `vi`; `./gradlew assembleRelease` to
+    confirm minified release loads `libsushi-pty.so`; existing SSH flows
+    (read+copy, restart service, run script) regression-tested; persistence
+    check via `adb shell run-as net.hlan.sushi cat files/...`.
+- *Branch 3 — Host-selection UX* — list of edits with file paths:
+  - `HostsActivity.kt:20-31` one-tap connect
+  - `HostEditActivity.kt:128-131` delete silent auto-select
+  - `SettingsActivity.kt:199-205` drop button wiring
+  - `app/src/main/res/layout/page_settings_ssh.xml:194-224` delete buttons
+  - **Verify:** manual click-path on device (SSH and Local); kind suffix
+    visible on connect button; settings page no longer shows Manage Hosts
+    buttons; saving a new host does not silently change the active host;
+    `./scripts/run-device-qa-suite.sh`.
+- *Cross-branch checks* — SonarQube on each branch before merge; release cut
+  on main after each branch lands; `./scripts/run-device-qa-suite.sh` clean
+  on every branch.
+- *Renaissance hand-off* — explicit note that `ConversationManager`,
+  `PlayRunner`, and `PersonaClient` deliberately stay typed on `SshClient`
+  through this work; the renaissance moves them onto `TerminalBackend` and
+  defines the plans-vs-results observability story.
+
+## Reuse callouts (cite in concept docs)
+
+- `TerminalActivity.createIntent(context, autoConnect)` already at
+  `TerminalActivity.kt:323`, used by `MainActivity:111,115`. Branch 3 calls it
+  from `HostsActivity`.
+- `SshConnectionConfig.displayTarget()` already at `SshClient.kt:48`. Branch
+  2 extends it; Branch 3 inherits the kind label for free.
+- `SshConnectResult` / `SshCommandResult` already at `SshClient.kt:55-64`;
+  reused as interface return types.
+- `SshSettings.getConfigOrNull()` (`SshSettings.kt:91-95`) already returns the
+  active host config; unchanged.
+- Moshi `KotlinJsonAdapterFactory` already configured in `SshSettings.kt:10`,
+  so the new `kind` field with a Kotlin default deserialises old JSON cleanly.
+
+## Verification (of this docs deliverable)
+
+- `tree docs/concepts` shows the four `.md` files; `ls docs/ROADMAP_*.md`
+  shows the roadmap.
+- Each concept doc opens with a one-paragraph "what this is" and ends with a
+  "critical files" list whose paths/lines all resolve in the current tree.
+- The roadmap's branch sections each list edits with concrete file paths and
+  a verify command/test that an implementer can run.
+- All four concept docs link back to each other and to the roadmap; the
+  roadmap links to each concept doc. Cross-links use relative paths
+  (`./concepts/TERMINAL_BACKEND.md` from the roadmap).
+- `git grep -n "FIXME\|TBD"` returns no hits in the new files.


### PR DESCRIPTION
## Summary

- Adds six planning/reference docs under `docs/` for the upcoming local-shell terminal and host-selection UX rework
- No source-code changes; documentation only
- Establishes the concepts and phased roadmap that implementation branches will follow

## What's in the docs

| File | Purpose |
|------|---------|
| `docs/concepts/TERMINAL_BACKEND.md` | `TerminalBackend` interface contract — abstracts SSH and local-shell backends |
| `docs/concepts/HOST_KIND.md` | `HostKind { SSH, LOCAL }` discriminator + synthetic "Local shell" host design |
| `docs/concepts/LOCAL_SHELL_PTY.md` | JNI PTY shim (`sushi-pty`) design — why custom over Termux, forkpty approach, ABI targets |
| `docs/concepts/HOST_SELECTION_UX.md` | One-tap connect, active-host in title bar, settings dedup, drop silent auto-select |
| `docs/ROADMAP_LOCAL_SHELL.md` | Three-branch phased plan with verify steps for each |
| `docs/plans/local-shell-rework-plan.md` | Full combined planning doc (problem statement, scope, design, critical files) |

## Context

Sushi is currently SSH-only. The user wants a local-shell terminal (full PTY so `vi`/`top`/`less` work) surfaced as just another host in the host list. During planning, the host-selection UX was identified as a separate pain point — connecting to a known host takes 6–8 taps today.

Plays and Gemini are out of scope for this work, reserved for a future redesign.

## Test plan

- [ ] All new files are markdown only — no build or lint impact
- [ ] Links between docs are relative and resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)