### PR TITLE
feat: polish Gemini dialog and transcript UI

### DIFF
--- a/app/src/main/res/drawable/bg_gemini_assistant_bubble.xml
+++ b/app/src/main/res/drawable/bg_gemini_assistant_bubble.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/sushi_ink" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/sushi_slate" />
+    <corners android:radius="18dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_gemini_user_bubble.xml
+++ b/app/src/main/res/drawable/bg_gemini_user_bubble.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/sushi_green" />
+    <corners android:radius="18dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_gemini_controls.xml
+++ b/app/src/main/res/layout/dialog_gemini_controls.xml
@@ -22,29 +22,49 @@
         android:layout_marginTop="8dp"
         android:text="@string/gemini_status_disabled" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/geminiDialogVoiceButton"
+        style="@style/Widget.Sushi.PrimaryButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="14dp"
+        android:text="@string/action_gemini_voice"
+        app:icon="@drawable/ic_mic"
+        app:iconGravity="textStart" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/geminiDialogSettingsButton"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/action_gemini_settings"
+        app:icon="@drawable/ic_settings"
+        app:iconGravity="textStart" />
+
     <!-- Text Input Section -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="14dp"
-        android:orientation="horizontal"
-        android:gravity="center_vertical">
-        
+        android:layout_marginTop="12dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
         <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_marginEnd="8dp"
-            android:hint="@string/conversation_input_hint"
-            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
-            
+            android:layout_weight="1"
+            android:hint="@string/conversation_input_hint">
+
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/geminiDialogTextInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:maxLines="3"
                 android:imeOptions="actionSend"
-                android:inputType="textCapSentences|textMultiLine" />
+                android:inputType="textCapSentences|textMultiLine"
+                android:maxLines="3" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
@@ -52,38 +72,8 @@
             style="@style/Widget.Material3.Button.IconButton.Filled"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            app:icon="@drawable/ic_send"
-            android:contentDescription="@string/action_send_message" />
-    </LinearLayout>
-
-    <!-- Voice and Settings Buttons -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:orientation="horizontal"
-        android:gravity="center">
-        
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/geminiDialogVoiceButton"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginEnd="8dp"
-            android:text="@string/action_gemini_voice"
-            app:icon="@drawable/ic_mic"
-            app:iconGravity="textStart" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/geminiDialogSettingsButton"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/action_gemini_settings"
-            app:icon="@drawable/ic_settings"
-            app:iconGravity="textStart" />
+            android:contentDescription="@string/action_send_message"
+            app:icon="@drawable/ic_send" />
     </LinearLayout>
 
     <TextView

--- a/app/src/main/res/layout/dialog_gemini_controls.xml
+++ b/app/src/main/res/layout/dialog_gemini_controls.xml
@@ -35,7 +35,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/geminiDialogSettingsButton"
         style="@style/Widget.Material3.Button.OutlinedButton"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:text="@string/action_gemini_settings"

--- a/app/src/main/res/layout/item_gemini_transcript.xml
+++ b/app/src/main/res/layout/item_gemini_transcript.xml
@@ -4,7 +4,8 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingBottom="8dp"
+    android:descendantFocusability="blocksDescendants">
 
     <TextView
         android:id="@+id/transcriptPromptLabel"
@@ -12,14 +13,26 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gemini_transcript_you_label"
+        android:textAlignment="viewEnd"
         android:textStyle="bold" />
 
     <TextView
         android:id="@+id/transcriptPromptContent"
         style="@style/TextAppearance.Sushi.Body"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp" />
+        android:layout_gravity="end"
+        android:layout_marginTop="4dp"
+        android:layout_marginStart="48dp"
+        android:background="@drawable/bg_gemini_user_bubble"
+        android:lineSpacingExtra="2dp"
+        android:maxWidth="280dp"
+        android:paddingLeft="12dp"
+        android:paddingTop="10dp"
+        android:paddingRight="12dp"
+        android:paddingBottom="10dp"
+        android:textAlignment="viewEnd"
+        android:textColor="@color/sushi_mist" />
 
     <TextView
         android:id="@+id/transcriptResponseLabel"
@@ -33,15 +46,23 @@
     <TextView
         android:id="@+id/transcriptResponseContent"
         style="@style/TextAppearance.Sushi.Body"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="start"
         android:layout_marginTop="2dp"
-        android:fontFamily="monospace" />
+        android:background="@drawable/bg_gemini_assistant_bubble"
+        android:lineSpacingExtra="2dp"
+        android:maxWidth="280dp"
+        android:paddingLeft="12dp"
+        android:paddingTop="10dp"
+        android:paddingRight="12dp"
+        android:paddingBottom="10dp"
+        android:textColor="@color/sushi_terminal_text" />
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="8dp"
-        android:background="?android:attr/listDivider" />
+        android:background="@color/sushi_card_stroke" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_gemini_transcript.xml
+++ b/app/src/main/res/layout/item_gemini_transcript.xml
@@ -27,9 +27,9 @@
         android:background="@drawable/bg_gemini_user_bubble"
         android:lineSpacingExtra="2dp"
         android:maxWidth="280dp"
-        android:paddingLeft="12dp"
+        android:paddingStart="12dp"
         android:paddingTop="10dp"
-        android:paddingRight="12dp"
+        android:paddingEnd="12dp"
         android:paddingBottom="10dp"
         android:textAlignment="viewEnd"
         android:textColor="@color/sushi_mist" />
@@ -50,12 +50,13 @@
         android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:layout_marginTop="2dp"
+        android:layout_marginEnd="48dp"
         android:background="@drawable/bg_gemini_assistant_bubble"
         android:lineSpacingExtra="2dp"
         android:maxWidth="280dp"
-        android:paddingLeft="12dp"
+        android:paddingStart="12dp"
         android:paddingTop="10dp"
-        android:paddingRight="12dp"
+        android:paddingEnd="12dp"
         android:paddingBottom="10dp"
         android:textColor="@color/sushi_terminal_text" />
 


### PR DESCRIPTION
## Summary

- Introduces chat-style bubble drawables for user and assistant messages in the Gemini transcript
- Refines the Gemini controls dialog layout

## Changes

- `bg_gemini_assistant_bubble.xml` — new drawable for assistant message bubbles
- `bg_gemini_user_bubble.xml` — new drawable for user message bubbles
- `dialog_gemini_controls.xml` — layout refinements; settings button now full-width
- `item_gemini_transcript.xml` — chat bubbles; RTL-friendly padding; assistant bubble margin

## Figma frame

> UI changes are layout/drawable only — chat bubble styling and dialog polish.
> No Figma frame exists for this component yet; the changes are visual refinements
> to existing screens rather than new designs from a spec.

## Test plan

- [ ] Open Gemini dialog, send a message — verify user and assistant bubbles render correctly
- [ ] Settings button spans full width
- [ ] Assistant bubble has right-side margin matching user bubble's left-side margin
- [ ] Check bubble styling in both light and dark mode
- [ ] No regressions in existing Gemini controls behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)