### PR TITLE
feat: local-shell backend + JNI PTY shim

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,7 @@ val hasKeystore = !keystorePath.isNullOrBlank() &&
 android {
     namespace = "net.hlan.sushi"
     compileSdk = 36
+    ndkVersion = "27.0.12077973"
 
     testBuildType = "minifiedDebug"
 
@@ -30,6 +31,19 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
+        }
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+        }
+        externalNativeBuild {
+            cmake { }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,6 +46,12 @@
 -keep class com.google.mlkit.** { *; }
 -dontwarn com.google.mlkit.**
 
+# Native methods must keep their JNI-resolvable names.
+-keepclasseswithmembernames class * { native <methods>; }
+
+# LocalShellBackend is referenced by JNI symbol names (Java_net_hlan_sushi_LocalShellBackend_native*).
+-keep class net.hlan.sushi.LocalShellBackend { *; }
+
 # ListAdapter.getCurrentList() is called from instrumented tests against the minified build.
 -keepclassmembers class * extends androidx.recyclerview.widget.ListAdapter {
     public java.util.List getCurrentList();

--- a/app/src/androidTest/java/net/hlan/sushi/DeviceQaSuiteTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/DeviceQaSuiteTest.kt
@@ -1,5 +1,6 @@
 package net.hlan.sushi
 
+import android.content.Intent
 import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
@@ -204,6 +205,69 @@ class DeviceQaSuiteTest {
                     targetPosition, click()
                 )
             )
+        }
+    }
+
+    @Test
+    fun localShellHostIsSeededAndAppearsInHostList() {
+        val context = instrumentation.targetContext
+        // clearState() wiped prefs; re-seed as Application.onCreate() would on first launch.
+        SshSettings(context).seedLocalHostIfMissing()
+
+        val sshSettings = SshSettings(context)
+        val localHosts = sshSettings.getHosts().filter { it.kind == HostKind.LOCAL }
+        assertTrue("At least one LOCAL host should exist after seeding", localHosts.isNotEmpty())
+        assertTrue(
+            "Seeded LOCAL host alias should not be blank",
+            localHosts.first().alias.isNotBlank()
+        )
+
+        // Verify the seeded host appears in HostsActivity list
+        launchActivity(HostsActivity::class.java).use { scenario ->
+            waitForCondition(scenario) { activity ->
+                val recycler = activity.findViewById<androidx.recyclerview.widget.RecyclerView>(
+                    R.id.hostsRecyclerView
+                )
+                recycler.adapter?.itemCount ?: 0 > 0
+            }
+            onView(withId(R.id.hostsRecyclerView))
+                .check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    fun localHostEditShowsOnlyAliasField() {
+        val context = instrumentation.targetContext
+        SshSettings(context).seedLocalHostIfMissing()
+
+        val localHost = SshSettings(context).getHosts().first { it.kind == HostKind.LOCAL }
+        val intent = Intent(context, HostEditActivity::class.java)
+            .putExtra(HostEditActivity.EXTRA_HOST_ID, localHost.id)
+
+        wakeAndUnlock()
+        Thread.sleep(400)
+        ActivityScenario.launch<HostEditActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.window.addFlags(
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
+                        @Suppress("DEPRECATION")
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                )
+            }
+
+            // Alias field must be visible and editable
+            onView(withId(R.id.hostAliasInput)).check(matches(isDisplayed()))
+
+            // SSH-specific fields must be hidden for LOCAL hosts
+            onView(withId(R.id.sshHostLayout)).check(matches(not(isDisplayed())))
+            onView(withId(R.id.sshPortLayout)).check(matches(not(isDisplayed())))
+            onView(withId(R.id.sshUsernameLayout)).check(matches(not(isDisplayed())))
+            onView(withId(R.id.sshPasswordLayout)).check(matches(not(isDisplayed())))
+            onView(withId(R.id.authPreferenceLayout)).check(matches(not(isDisplayed())))
+            onView(withId(R.id.jumpEnabledSwitch)).check(matches(not(isDisplayed())))
+
+            // Delete button must be hidden so the synthetic host cannot be removed
+            onView(withId(R.id.deleteButton)).check(matches(not(isDisplayed())))
         }
     }
 

--- a/app/src/androidTest/java/net/hlan/sushi/LocalShellBackendTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/LocalShellBackendTest.kt
@@ -1,0 +1,129 @@
+package net.hlan.sushi
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Collections
+
+/**
+ * Instrumented tests for LocalShellBackend. These run entirely on-device via the
+ * real PTY shim (libsushi-pty.so) with no network required — suitable for CI
+ * emulators and for regression-testing after ProGuard minification.
+ */
+@RunWith(AndroidJUnit4::class)
+class LocalShellBackendTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private var backend: LocalShellBackend? = null
+
+    @After
+    fun teardown() {
+        backend?.disconnect()
+        backend = null
+    }
+
+    @Test
+    fun nativeLibraryLoads() {
+        // Accessing LocalShellBackend triggers System.loadLibrary("sushi-pty") in
+        // the companion object init block. This is the ProGuard smoke-test: if the
+        // keep rules are wrong the class or its native methods are stripped and
+        // this line throws UnsatisfiedLinkError.
+        backend = LocalShellBackend(context)
+        assertNotNull(backend)
+    }
+
+    @Test
+    fun connectReturnsSuccessAndIsConnectedIsTrue() {
+        backend = LocalShellBackend(context)
+        val result = backend!!.connect(onLine = {}, streamMode = true)
+        assertTrue("connect() should succeed: ${result.message}", result.success)
+        assertTrue("isConnected() should be true after connect", backend!!.isConnected())
+    }
+
+    @Test
+    fun disconnectClearsConnectedState() {
+        backend = LocalShellBackend(context)
+        backend!!.connect(onLine = {}, streamMode = true)
+        assertTrue(backend!!.isConnected())
+        backend!!.disconnect()
+        assertFalse("isConnected() should be false after disconnect", backend!!.isConnected())
+    }
+
+    @Test
+    fun echoCommandOutputIsReceived() {
+        val lines = Collections.synchronizedList(mutableListOf<String>())
+        backend = LocalShellBackend(context)
+        val connectResult = backend!!.connect(onLine = { lines.add(it) }, streamMode = true)
+        assertTrue("connect() should succeed", connectResult.success)
+
+        val marker = "SUSHI_PTY_TEST_${System.currentTimeMillis()}"
+        Thread.sleep(300) // wait for shell to be ready
+        backend!!.sendCommand("echo $marker")
+
+        waitUntil(timeoutMs = 5_000, message = "Output should contain marker '$marker'") {
+            lines.any { it.contains(marker) }
+        }
+    }
+
+    @Test
+    fun resizePtyDoesNotCrash() {
+        backend = LocalShellBackend(context)
+        backend!!.connect(onLine = {}, streamMode = true)
+        // Should not throw — verifies that TIOCSWINSZ ioctl reaches the kernel
+        backend!!.resizePty(col = 120, row = 40, widthPx = 1200, heightPx = 800)
+        backend!!.resizePty(col = 80, row = 24, widthPx = 800, heightPx = 480)
+    }
+
+    @Test
+    fun sendCtrlCDoesNotCrash() {
+        backend = LocalShellBackend(context)
+        backend!!.connect(onLine = {}, streamMode = true)
+        Thread.sleep(200)
+        backend!!.sendCtrlC()
+    }
+
+    @Test
+    fun sendTextReturnsSuccess() {
+        backend = LocalShellBackend(context)
+        backend!!.connect(onLine = {}, streamMode = true)
+        Thread.sleep(200)
+        val result = backend!!.sendText("ls\n")
+        assertTrue("sendText should return success: ${result.message}", result.success)
+    }
+
+    @Test
+    fun termEnvIsXterm256color() {
+        val lines = Collections.synchronizedList(mutableListOf<String>())
+        backend = LocalShellBackend(context)
+        backend!!.connect(onLine = { lines.add(it) }, streamMode = true)
+
+        Thread.sleep(300)
+        backend!!.sendCommand("echo TERM=$TERM")
+
+        waitUntil(timeoutMs = 5_000, message = "TERM should be xterm-256color") {
+            lines.any { it.contains("xterm-256color") }
+        }
+    }
+
+    @Test
+    fun sendTextOnDisconnectedBackendReturnsFailure() {
+        backend = LocalShellBackend(context)
+        // Never connected — nativeHandle is 0
+        val result = backend!!.sendText("hello")
+        assertFalse("sendText without connect should return failure", result.success)
+    }
+
+    private fun waitUntil(timeoutMs: Long, message: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(100)
+        }
+        throw AssertionError(message)
+    }
+}

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(sushi-pty C)
+
+add_library(sushi-pty SHARED sushi-pty.c)
+target_link_libraries(sushi-pty log)

--- a/app/src/main/cpp/sushi-pty.c
+++ b/app/src/main/cpp/sushi-pty.c
@@ -24,28 +24,50 @@ Java_net_hlan_sushi_LocalShellBackend_nativeStart(
         JNIEnv *env, jclass clazz,
         jstring cmd, jobjectArray argv, jobjectArray envp) {
 
-    const char *cmd_str = (*env)->GetStringUTFChars(env, cmd, NULL);
+    /* strdup cmd immediately so the JNI reference can be released at once. */
+    const char *cmd_utf = (*env)->GetStringUTFChars(env, cmd, NULL);
+    if (!cmd_utf) return 0L;
+    char *cmd_str = strdup(cmd_utf);
+    (*env)->ReleaseStringUTFChars(env, cmd, cmd_utf);
     if (!cmd_str) return 0L;
 
     jsize argc = (*env)->GetArrayLength(env, argv);
     jsize envc = (*env)->GetArrayLength(env, envp);
 
-    const char **c_argv = calloc(argc + 1, sizeof(char *));
-    const char **c_envp = calloc(envc + 1, sizeof(char *));
+    char **c_argv = calloc(argc + 1, sizeof(char *));
+    char **c_envp = calloc(envc + 1, sizeof(char *));
     if (!c_argv || !c_envp) {
-        free(c_argv);
-        free(c_envp);
-        (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+        free(c_argv); free(c_envp); free(cmd_str);
         return 0L;
     }
 
+    /*
+     * strdup each string immediately after GetStringUTFChars so we can
+     * ReleaseStringUTFChars + DeleteLocalRef inside the same iteration.
+     * This avoids accumulating JNI local references (limit ~512) and
+     * eliminates a second GetObjectArrayElement pass in the parent cleanup.
+     */
     for (jsize i = 0; i < argc; i++) {
-        jstring s = (*env)->GetObjectArrayElement(env, argv, i);
-        c_argv[i] = (*env)->GetStringUTFChars(env, s, NULL);
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, argv, i);
+        if (s) {
+            const char *utf = (*env)->GetStringUTFChars(env, s, NULL);
+            if (utf) {
+                c_argv[i] = strdup(utf);
+                (*env)->ReleaseStringUTFChars(env, s, utf);
+            }
+            (*env)->DeleteLocalRef(env, s);
+        }
     }
     for (jsize i = 0; i < envc; i++) {
-        jstring s = (*env)->GetObjectArrayElement(env, envp, i);
-        c_envp[i] = (*env)->GetStringUTFChars(env, s, NULL);
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, envp, i);
+        if (s) {
+            const char *utf = (*env)->GetStringUTFChars(env, s, NULL);
+            if (utf) {
+                c_envp[i] = strdup(utf);
+                (*env)->ReleaseStringUTFChars(env, s, utf);
+            }
+            (*env)->DeleteLocalRef(env, s);
+        }
     }
 
     int master_fd;
@@ -53,54 +75,36 @@ Java_net_hlan_sushi_LocalShellBackend_nativeStart(
 
     if (child_pid < 0) {
         LOGE("forkpty failed: %s", strerror(errno));
-        for (jsize i = 0; i < argc; i++) {
-            jstring s = (*env)->GetObjectArrayElement(env, argv, i);
-            (*env)->ReleaseStringUTFChars(env, s, c_argv[i]);
-        }
-        for (jsize i = 0; i < envc; i++) {
-            jstring s = (*env)->GetObjectArrayElement(env, envp, i);
-            (*env)->ReleaseStringUTFChars(env, s, c_envp[i]);
-        }
-        free(c_argv);
-        free(c_envp);
-        (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+        for (jsize i = 0; i < argc; i++) free(c_argv[i]);
+        for (jsize i = 0; i < envc; i++) free(c_envp[i]);
+        free(c_argv); free(c_envp); free(cmd_str);
         return 0L;
     }
 
     if (child_pid == 0) {
-        // child process
+        /* child: apply env then exec; _exit on failure so atexit is skipped */
         for (jsize i = 0; i < envc; i++) {
+            if (!c_envp[i]) continue;
             char *kv = strdup(c_envp[i]);
             if (!kv) continue;
             char *eq = strchr(kv, '=');
-            if (eq) {
-                *eq = '\0';
-                setenv(kv, eq + 1, 1);
-            }
-            free(kv);
+            if (eq) { *eq = '\0'; setenv(kv, eq + 1, 1); }
+            /* intentionally not freed — exec replaces the address space */
         }
-        execvp(cmd_str, (char *const *)c_argv);
+        execvp(cmd_str, c_argv);
         _exit(127);
     }
 
-    // parent: set FD_CLOEXEC on master so it doesn't leak into other forks
+    /* parent: FD_CLOEXEC so master_fd doesn't leak into later forks */
     fcntl(master_fd, F_SETFD, FD_CLOEXEC);
-
-    for (jsize i = 0; i < argc; i++) {
-        jstring s = (*env)->GetObjectArrayElement(env, argv, i);
-        (*env)->ReleaseStringUTFChars(env, s, c_argv[i]);
-    }
-    for (jsize i = 0; i < envc; i++) {
-        jstring s = (*env)->GetObjectArrayElement(env, envp, i);
-        (*env)->ReleaseStringUTFChars(env, s, c_envp[i]);
-    }
-    free(c_argv);
-    free(c_envp);
-    (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+    for (jsize i = 0; i < argc; i++) free(c_argv[i]);
+    for (jsize i = 0; i < envc; i++) free(c_envp[i]);
+    free(c_argv); free(c_envp); free(cmd_str);
 
     PtySession *sess = malloc(sizeof(PtySession));
     if (!sess) {
         kill(child_pid, SIGHUP);
+        waitpid(child_pid, NULL, 0); /* reap to avoid zombie */
         close(master_fd);
         return 0L;
     }

--- a/app/src/main/cpp/sushi-pty.c
+++ b/app/src/main/cpp/sushi-pty.c
@@ -1,0 +1,180 @@
+#include <jni.h>
+#include <pty.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <android/log.h>
+
+#define TAG "sushi-pty"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+typedef struct {
+    int master_fd;
+    pid_t child_pid;
+} PtySession;
+
+JNIEXPORT jlong JNICALL
+Java_net_hlan_sushi_LocalShellBackend_nativeStart(
+        JNIEnv *env, jclass clazz,
+        jstring cmd, jobjectArray argv, jobjectArray envp) {
+
+    const char *cmd_str = (*env)->GetStringUTFChars(env, cmd, NULL);
+    if (!cmd_str) return 0L;
+
+    jsize argc = (*env)->GetArrayLength(env, argv);
+    jsize envc = (*env)->GetArrayLength(env, envp);
+
+    const char **c_argv = calloc(argc + 1, sizeof(char *));
+    const char **c_envp = calloc(envc + 1, sizeof(char *));
+    if (!c_argv || !c_envp) {
+        free(c_argv);
+        free(c_envp);
+        (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+        return 0L;
+    }
+
+    for (jsize i = 0; i < argc; i++) {
+        jstring s = (*env)->GetObjectArrayElement(env, argv, i);
+        c_argv[i] = (*env)->GetStringUTFChars(env, s, NULL);
+    }
+    for (jsize i = 0; i < envc; i++) {
+        jstring s = (*env)->GetObjectArrayElement(env, envp, i);
+        c_envp[i] = (*env)->GetStringUTFChars(env, s, NULL);
+    }
+
+    int master_fd;
+    pid_t child_pid = forkpty(&master_fd, NULL, NULL, NULL);
+
+    if (child_pid < 0) {
+        LOGE("forkpty failed: %s", strerror(errno));
+        for (jsize i = 0; i < argc; i++) {
+            jstring s = (*env)->GetObjectArrayElement(env, argv, i);
+            (*env)->ReleaseStringUTFChars(env, s, c_argv[i]);
+        }
+        for (jsize i = 0; i < envc; i++) {
+            jstring s = (*env)->GetObjectArrayElement(env, envp, i);
+            (*env)->ReleaseStringUTFChars(env, s, c_envp[i]);
+        }
+        free(c_argv);
+        free(c_envp);
+        (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+        return 0L;
+    }
+
+    if (child_pid == 0) {
+        // child process
+        for (jsize i = 0; i < envc; i++) {
+            char *kv = strdup(c_envp[i]);
+            if (!kv) continue;
+            char *eq = strchr(kv, '=');
+            if (eq) {
+                *eq = '\0';
+                setenv(kv, eq + 1, 1);
+            }
+            free(kv);
+        }
+        execvp(cmd_str, (char *const *)c_argv);
+        _exit(127);
+    }
+
+    // parent: set FD_CLOEXEC on master so it doesn't leak into other forks
+    fcntl(master_fd, F_SETFD, FD_CLOEXEC);
+
+    for (jsize i = 0; i < argc; i++) {
+        jstring s = (*env)->GetObjectArrayElement(env, argv, i);
+        (*env)->ReleaseStringUTFChars(env, s, c_argv[i]);
+    }
+    for (jsize i = 0; i < envc; i++) {
+        jstring s = (*env)->GetObjectArrayElement(env, envp, i);
+        (*env)->ReleaseStringUTFChars(env, s, c_envp[i]);
+    }
+    free(c_argv);
+    free(c_envp);
+    (*env)->ReleaseStringUTFChars(env, cmd, cmd_str);
+
+    PtySession *sess = malloc(sizeof(PtySession));
+    if (!sess) {
+        kill(child_pid, SIGHUP);
+        close(master_fd);
+        return 0L;
+    }
+    sess->master_fd = master_fd;
+    sess->child_pid = child_pid;
+    return (jlong)(uintptr_t)sess;
+}
+
+JNIEXPORT jint JNICALL
+Java_net_hlan_sushi_LocalShellBackend_nativeRead(
+        JNIEnv *env, jclass clazz, jlong handle, jbyteArray buf) {
+
+    PtySession *sess = (PtySession *)(uintptr_t)handle;
+    jsize len = (*env)->GetArrayLength(env, buf);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, buf, NULL);
+    if (!bytes) return -1;
+
+    ssize_t n;
+    do {
+        n = read(sess->master_fd, bytes, (size_t)len);
+    } while (n < 0 && errno == EINTR);
+
+    if (n < 0 && errno == EIO) n = -1;
+
+    (*env)->ReleaseByteArrayElements(env, buf, bytes, n > 0 ? 0 : JNI_ABORT);
+    return (jint)n;
+}
+
+JNIEXPORT jint JNICALL
+Java_net_hlan_sushi_LocalShellBackend_nativeWrite(
+        JNIEnv *env, jclass clazz, jlong handle, jbyteArray data) {
+
+    PtySession *sess = (PtySession *)(uintptr_t)handle;
+    jsize len = (*env)->GetArrayLength(env, data);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, data, NULL);
+    if (!bytes) return -1;
+
+    ssize_t written = 0;
+    while (written < len) {
+        ssize_t n;
+        do {
+            n = write(sess->master_fd, bytes + written, (size_t)(len - written));
+        } while (n < 0 && errno == EINTR);
+        if (n <= 0) break;
+        written += n;
+    }
+
+    (*env)->ReleaseByteArrayElements(env, data, bytes, JNI_ABORT);
+    return (jint)written;
+}
+
+JNIEXPORT void JNICALL
+Java_net_hlan_sushi_LocalShellBackend_nativeResize(
+        JNIEnv *env, jclass clazz, jlong handle,
+        jint col, jint row, jint widthPx, jint heightPx) {
+
+    PtySession *sess = (PtySession *)(uintptr_t)handle;
+    struct winsize ws;
+    memset(&ws, 0, sizeof(ws));
+    ws.ws_col = (unsigned short)col;
+    ws.ws_row = (unsigned short)row;
+    ws.ws_xpixel = (unsigned short)widthPx;
+    ws.ws_ypixel = (unsigned short)heightPx;
+    ioctl(sess->master_fd, TIOCSWINSZ, &ws);
+}
+
+JNIEXPORT void JNICALL
+Java_net_hlan_sushi_LocalShellBackend_nativeClose(
+        JNIEnv *env, jclass clazz, jlong handle) {
+
+    if (handle == 0L) return;
+    PtySession *sess = (PtySession *)(uintptr_t)handle;
+    kill(sess->child_pid, SIGHUP);
+    waitpid(sess->child_pid, NULL, 0);
+    close(sess->master_fd);
+    free(sess);
+}

--- a/app/src/main/cpp/sushi-pty.c
+++ b/app/src/main/cpp/sushi-pty.c
@@ -19,6 +19,46 @@ typedef struct {
     pid_t child_pid;
 } PtySession;
 
+/*
+ * Copy a Java String[] into a NULL-terminated C string array.
+ * Each element is strdup'd and the JNI local ref is released in the same
+ * iteration to avoid accumulating references (limit ~512).
+ */
+static char **copy_jstring_array(JNIEnv *env, jobjectArray arr, jsize len) {
+    char **out = calloc(len + 1, sizeof(char *));
+    if (!out) return NULL;
+    for (jsize i = 0; i < len; i++) {
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, arr, i);
+        if (s) {
+            const char *utf = (*env)->GetStringUTFChars(env, s, NULL);
+            if (utf) {
+                out[i] = strdup(utf);
+                (*env)->ReleaseStringUTFChars(env, s, utf);
+            }
+            (*env)->DeleteLocalRef(env, s);
+        }
+    }
+    return out;
+}
+
+static void free_string_array(char **arr, jsize len) {
+    if (!arr) return;
+    for (jsize i = 0; i < len; i++) free(arr[i]);
+    free(arr);
+}
+
+/* Apply KEY=VALUE pairs from envp to the process environment. */
+static void apply_env(char **envp, jsize envc) {
+    for (jsize i = 0; i < envc; i++) {
+        if (!envp[i]) continue;
+        char *kv = strdup(envp[i]);
+        if (!kv) continue;
+        char *eq = strchr(kv, '=');
+        if (eq) { *eq = '\0'; setenv(kv, eq + 1, 1); }
+        /* intentionally not freed — exec replaces the address space */
+    }
+}
+
 JNIEXPORT jlong JNICALL
 Java_net_hlan_sushi_LocalShellBackend_nativeStart(
         JNIEnv *env, jclass clazz,
@@ -34,40 +74,13 @@ Java_net_hlan_sushi_LocalShellBackend_nativeStart(
     jsize argc = (*env)->GetArrayLength(env, argv);
     jsize envc = (*env)->GetArrayLength(env, envp);
 
-    char **c_argv = calloc(argc + 1, sizeof(char *));
-    char **c_envp = calloc(envc + 1, sizeof(char *));
+    char **c_argv = copy_jstring_array(env, argv, argc);
+    char **c_envp = copy_jstring_array(env, envp, envc);
     if (!c_argv || !c_envp) {
-        free(c_argv); free(c_envp); free(cmd_str);
+        free_string_array(c_argv, argc);
+        free_string_array(c_envp, envc);
+        free(cmd_str);
         return 0L;
-    }
-
-    /*
-     * strdup each string immediately after GetStringUTFChars so we can
-     * ReleaseStringUTFChars + DeleteLocalRef inside the same iteration.
-     * This avoids accumulating JNI local references (limit ~512) and
-     * eliminates a second GetObjectArrayElement pass in the parent cleanup.
-     */
-    for (jsize i = 0; i < argc; i++) {
-        jstring s = (jstring)(*env)->GetObjectArrayElement(env, argv, i);
-        if (s) {
-            const char *utf = (*env)->GetStringUTFChars(env, s, NULL);
-            if (utf) {
-                c_argv[i] = strdup(utf);
-                (*env)->ReleaseStringUTFChars(env, s, utf);
-            }
-            (*env)->DeleteLocalRef(env, s);
-        }
-    }
-    for (jsize i = 0; i < envc; i++) {
-        jstring s = (jstring)(*env)->GetObjectArrayElement(env, envp, i);
-        if (s) {
-            const char *utf = (*env)->GetStringUTFChars(env, s, NULL);
-            if (utf) {
-                c_envp[i] = strdup(utf);
-                (*env)->ReleaseStringUTFChars(env, s, utf);
-            }
-            (*env)->DeleteLocalRef(env, s);
-        }
     }
 
     int master_fd;
@@ -75,31 +88,24 @@ Java_net_hlan_sushi_LocalShellBackend_nativeStart(
 
     if (child_pid < 0) {
         LOGE("forkpty failed: %s", strerror(errno));
-        for (jsize i = 0; i < argc; i++) free(c_argv[i]);
-        for (jsize i = 0; i < envc; i++) free(c_envp[i]);
-        free(c_argv); free(c_envp); free(cmd_str);
+        free_string_array(c_argv, argc);
+        free_string_array(c_envp, envc);
+        free(cmd_str);
         return 0L;
     }
 
     if (child_pid == 0) {
         /* child: apply env then exec; _exit on failure so atexit is skipped */
-        for (jsize i = 0; i < envc; i++) {
-            if (!c_envp[i]) continue;
-            char *kv = strdup(c_envp[i]);
-            if (!kv) continue;
-            char *eq = strchr(kv, '=');
-            if (eq) { *eq = '\0'; setenv(kv, eq + 1, 1); }
-            /* intentionally not freed — exec replaces the address space */
-        }
+        apply_env(c_envp, envc);
         execvp(cmd_str, c_argv);
         _exit(127);
     }
 
     /* parent: FD_CLOEXEC so master_fd doesn't leak into later forks */
     fcntl(master_fd, F_SETFD, FD_CLOEXEC);
-    for (jsize i = 0; i < argc; i++) free(c_argv[i]);
-    for (jsize i = 0; i < envc; i++) free(c_envp[i]);
-    free(c_argv); free(c_envp); free(cmd_str);
+    free_string_array(c_argv, argc);
+    free_string_array(c_envp, envc);
+    free(cmd_str);
 
     PtySession *sess = malloc(sizeof(PtySession));
     if (!sess) {

--- a/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
@@ -11,6 +11,7 @@ class HostEditActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHostEditBinding
     private val sshSettings by lazy { SshSettings(this) }
     private var hostId: String? = null
+    private var currentKind: HostKind = HostKind.SSH
     private var jumpOptions: List<SshConnectionConfig> = emptyList()
     private var selectedJumpHostId: String? = null
     private var authPreferenceOptions: List<Pair<String, String>> = emptyList()
@@ -28,7 +29,6 @@ class HostEditActivity : AppCompatActivity() {
 
         if (isEditMode) {
             binding.editHostTitle.text = getString(R.string.edit_host_title)
-            binding.deleteButton.visibility = View.VISIBLE
             loadHostData(hostId!!)
         } else {
             binding.editHostTitle.text = getString(R.string.add_host_title)
@@ -62,70 +62,104 @@ class HostEditActivity : AppCompatActivity() {
             return
         }
 
+        currentKind = host.kind
         binding.hostAliasInput.setText(host.alias)
-        binding.sshHostInput.setText(host.host)
-        binding.sshPortInput.setText(host.port.toString())
-        binding.sshUsernameInput.setText(host.username)
-        binding.sshPasswordInput.setText(host.password)
-        binding.authPreferenceInput.setText(authLabelForValue(host.authPreference), false)
 
-        val jumpHostId = host.jumpHostId
-        if (!jumpHostId.isNullOrBlank()) {
-            val index = jumpOptions.indexOfFirst { option -> option.id == jumpHostId }
-            if (index >= 0) {
-                selectedJumpHostId = jumpOptions[index].id
-                binding.jumpServerInput.setText(buildJumpLabel(jumpOptions[index]), false)
+        if (host.kind == HostKind.LOCAL) {
+            applySshFieldVisibility(visible = false)
+            binding.deleteButton.visibility = View.GONE
+        } else {
+            applySshFieldVisibility(visible = true)
+            binding.deleteButton.visibility = View.VISIBLE
+            binding.sshHostInput.setText(host.host)
+            binding.sshPortInput.setText(host.port.toString())
+            binding.sshUsernameInput.setText(host.username)
+            binding.sshPasswordInput.setText(host.password)
+            binding.authPreferenceInput.setText(authLabelForValue(host.authPreference), false)
+
+            val jumpHostId = host.jumpHostId
+            if (!jumpHostId.isNullOrBlank()) {
+                val index = jumpOptions.indexOfFirst { option -> option.id == jumpHostId }
+                if (index >= 0) {
+                    selectedJumpHostId = jumpOptions[index].id
+                    binding.jumpServerInput.setText(buildJumpLabel(jumpOptions[index]), false)
+                }
             }
+            binding.jumpEnabledSwitch.isChecked = host.jumpEnabled && selectedJumpHostId != null
+            updateJumpSectionVisibility(binding.jumpEnabledSwitch.isChecked)
         }
+    }
 
-        binding.jumpEnabledSwitch.isChecked = host.jumpEnabled && selectedJumpHostId != null
-        updateJumpSectionVisibility(binding.jumpEnabledSwitch.isChecked)
+    private fun applySshFieldVisibility(visible: Boolean) {
+        val v = if (visible) View.VISIBLE else View.GONE
+        binding.sshHostLayout.visibility = v
+        binding.sshPortLayout.visibility = v
+        binding.sshUsernameLayout.visibility = v
+        binding.sshPasswordLayout.visibility = v
+        binding.authPreferenceLayout.visibility = v
+        binding.jumpEnabledSwitch.visibility = v
+        binding.jumpServerLayout.visibility = View.GONE
+        binding.jumpHelperText.visibility = View.GONE
     }
 
     private fun saveHost() {
-        val host = binding.sshHostInput.text?.toString()?.trim().orEmpty()
-        val username = binding.sshUsernameInput.text?.toString()?.trim().orEmpty()
-        
-        if (host.isBlank() || username.isBlank()) {
-            Toast.makeText(this, "Host and Username are required", Toast.LENGTH_SHORT).show()
-            return
-        }
+        val alias = binding.hostAliasInput.text?.toString()?.trim().orEmpty()
 
-        val portInput = binding.sshPortInput.text?.toString()?.trim().orEmpty()
-        val parsedPort = portInput.toIntOrNull()
-        val port = if (parsedPort != null && parsedPort in 1..65535) {
-            parsedPort
+        val config = if (currentKind == HostKind.LOCAL) {
+            SshConnectionConfig(
+                kind = HostKind.LOCAL,
+                id = hostId ?: java.util.UUID.randomUUID().toString(),
+                alias = alias,
+                host = "",
+                port = 0,
+                username = "",
+                password = "",
+            )
         } else {
-            Toast.makeText(this, getString(R.string.ssh_invalid_port), Toast.LENGTH_SHORT).show()
-            binding.sshPortInput.setText("22")
-            return
-        }
+            val host = binding.sshHostInput.text?.toString()?.trim().orEmpty()
+            val username = binding.sshUsernameInput.text?.toString()?.trim().orEmpty()
 
-        val jumpEnabled = binding.jumpEnabledSwitch.isChecked && jumpOptions.isNotEmpty()
-        if (jumpEnabled && selectedJumpHostId.isNullOrBlank()) {
-            Toast.makeText(this, getString(R.string.jump_required_selection), Toast.LENGTH_SHORT).show()
-            return
-        }
+            if (host.isBlank() || username.isBlank()) {
+                Toast.makeText(this, "Host and Username are required", Toast.LENGTH_SHORT).show()
+                return
+            }
 
-        val config = SshConnectionConfig(
-            id = hostId ?: java.util.UUID.randomUUID().toString(),
-            alias = binding.hostAliasInput.text?.toString()?.trim().orEmpty(),
-            host = host,
-            port = port,
-            username = username,
-            password = binding.sshPasswordInput.text?.toString().orEmpty(),
-            authPreference = authValueFromInput(),
-            jumpEnabled = jumpEnabled,
-            jumpHostId = if (jumpEnabled) selectedJumpHostId else null,
-            jumpHost = "",
-            jumpPort = 22,
-            jumpUsername = "",
-            jumpPassword = ""
-        )
+            val portInput = binding.sshPortInput.text?.toString()?.trim().orEmpty()
+            val parsedPort = portInput.toIntOrNull()
+            val port = if (parsedPort != null && parsedPort in 1..65535) {
+                parsedPort
+            } else {
+                Toast.makeText(this, getString(R.string.ssh_invalid_port), Toast.LENGTH_SHORT).show()
+                binding.sshPortInput.setText("22")
+                return
+            }
+
+            val jumpEnabled = binding.jumpEnabledSwitch.isChecked && jumpOptions.isNotEmpty()
+            if (jumpEnabled && selectedJumpHostId.isNullOrBlank()) {
+                Toast.makeText(this, getString(R.string.jump_required_selection), Toast.LENGTH_SHORT).show()
+                return
+            }
+
+            SshConnectionConfig(
+                kind = HostKind.SSH,
+                id = hostId ?: java.util.UUID.randomUUID().toString(),
+                alias = alias,
+                host = host,
+                port = port,
+                username = username,
+                password = binding.sshPasswordInput.text?.toString().orEmpty(),
+                authPreference = authValueFromInput(),
+                jumpEnabled = jumpEnabled,
+                jumpHostId = if (jumpEnabled) selectedJumpHostId else null,
+                jumpHost = "",
+                jumpPort = 22,
+                jumpUsername = "",
+                jumpPassword = ""
+            )
+        }
 
         sshSettings.saveHost(config)
-        
-        // Auto-select if it's the first host or just created
+
         if (sshSettings.getActiveHostId() == null) {
             sshSettings.setActiveHostId(config.id)
         }
@@ -159,7 +193,7 @@ class HostEditActivity : AppCompatActivity() {
     private fun setupJumpOptions() {
         jumpOptions = sshSettings
             .getHosts()
-            .filter { host -> host.id != hostId }
+            .filter { host -> host.id != hostId && host.kind == HostKind.SSH }
 
         val labels = jumpOptions.map { option -> buildJumpLabel(option) }
         val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, labels)

--- a/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
@@ -104,68 +104,68 @@ class HostEditActivity : AppCompatActivity() {
 
     private fun saveHost() {
         val alias = binding.hostAliasInput.text?.toString()?.trim().orEmpty()
-
         val config = if (currentKind == HostKind.LOCAL) {
-            SshConnectionConfig(
-                kind = HostKind.LOCAL,
-                id = hostId ?: java.util.UUID.randomUUID().toString(),
-                alias = alias,
-                host = "",
-                port = 0,
-                username = "",
-                password = "",
-            )
+            buildLocalConfig(alias)
         } else {
-            val host = binding.sshHostInput.text?.toString()?.trim().orEmpty()
-            val username = binding.sshUsernameInput.text?.toString()?.trim().orEmpty()
-
-            if (host.isBlank() || username.isBlank()) {
-                Toast.makeText(this, "Host and Username are required", Toast.LENGTH_SHORT).show()
-                return
-            }
-
-            val portInput = binding.sshPortInput.text?.toString()?.trim().orEmpty()
-            val parsedPort = portInput.toIntOrNull()
-            val port = if (parsedPort != null && parsedPort in 1..65535) {
-                parsedPort
-            } else {
-                Toast.makeText(this, getString(R.string.ssh_invalid_port), Toast.LENGTH_SHORT).show()
-                binding.sshPortInput.setText("22")
-                return
-            }
-
-            val jumpEnabled = binding.jumpEnabledSwitch.isChecked && jumpOptions.isNotEmpty()
-            if (jumpEnabled && selectedJumpHostId.isNullOrBlank()) {
-                Toast.makeText(this, getString(R.string.jump_required_selection), Toast.LENGTH_SHORT).show()
-                return
-            }
-
-            SshConnectionConfig(
-                kind = HostKind.SSH,
-                id = hostId ?: java.util.UUID.randomUUID().toString(),
-                alias = alias,
-                host = host,
-                port = port,
-                username = username,
-                password = binding.sshPasswordInput.text?.toString().orEmpty(),
-                authPreference = authValueFromInput(),
-                jumpEnabled = jumpEnabled,
-                jumpHostId = if (jumpEnabled) selectedJumpHostId else null,
-                jumpHost = "",
-                jumpPort = 22,
-                jumpUsername = "",
-                jumpPassword = ""
-            )
+            buildSshConfig(alias) ?: return
         }
-
         sshSettings.saveHost(config)
-
         if (sshSettings.getActiveHostId() == null) {
             sshSettings.setActiveHostId(config.id)
         }
-
         Toast.makeText(this, getString(R.string.settings_saved), Toast.LENGTH_SHORT).show()
         finish()
+    }
+
+    private fun buildLocalConfig(alias: String): SshConnectionConfig =
+        SshConnectionConfig(
+            kind = HostKind.LOCAL,
+            id = hostId ?: java.util.UUID.randomUUID().toString(),
+            alias = alias,
+            host = "",
+            port = 0,
+            username = "",
+            password = "",
+        )
+
+    private fun buildSshConfig(alias: String): SshConnectionConfig? {
+        val host = binding.sshHostInput.text?.toString()?.trim().orEmpty()
+        val username = binding.sshUsernameInput.text?.toString()?.trim().orEmpty()
+        if (host.isBlank() || username.isBlank()) {
+            Toast.makeText(this, "Host and Username are required", Toast.LENGTH_SHORT).show()
+            return null
+        }
+
+        val portInput = binding.sshPortInput.text?.toString()?.trim().orEmpty()
+        val parsedPort = portInput.toIntOrNull()
+        if (parsedPort == null || parsedPort !in 1..65535) {
+            Toast.makeText(this, getString(R.string.ssh_invalid_port), Toast.LENGTH_SHORT).show()
+            binding.sshPortInput.setText("22")
+            return null
+        }
+
+        val jumpEnabled = binding.jumpEnabledSwitch.isChecked && jumpOptions.isNotEmpty()
+        if (jumpEnabled && selectedJumpHostId.isNullOrBlank()) {
+            Toast.makeText(this, getString(R.string.jump_required_selection), Toast.LENGTH_SHORT).show()
+            return null
+        }
+
+        return SshConnectionConfig(
+            kind = HostKind.SSH,
+            id = hostId ?: java.util.UUID.randomUUID().toString(),
+            alias = alias,
+            host = host,
+            port = parsedPort,
+            username = username,
+            password = binding.sshPasswordInput.text?.toString().orEmpty(),
+            authPreference = authValueFromInput(),
+            jumpEnabled = jumpEnabled,
+            jumpHostId = if (jumpEnabled) selectedJumpHostId else null,
+            jumpHost = "",
+            jumpPort = 22,
+            jumpUsername = "",
+            jumpPassword = ""
+        )
     }
 
     private fun setupAuthPreferenceOptions() {

--- a/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
@@ -1,6 +1,9 @@
 package net.hlan.sushi
 
 import android.content.Context
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.charset.CodingErrorAction
 
 class LocalShellBackend(private val context: Context) : TerminalBackend {
     private var nativeHandle: Long = 0L
@@ -72,12 +75,29 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
         val h = nativeHandle
         readerThread = Thread {
             val buf = ByteArray(4096)
+            // CharsetDecoder accumulates bytes across read() calls so that
+            // multi-byte UTF-8 sequences split at a read boundary are decoded
+            // correctly instead of producing replacement characters.
+            val decoder = Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE)
+            val charBuf = CharBuffer.allocate(8192)
             val lineBuffer = StringBuilder()
+            var pending = ByteArray(0)
             try {
                 while (true) {
                     val n = nativeRead(h, buf)
                     if (n <= 0) break
-                    val chunk = String(buf, 0, n, Charsets.UTF_8)
+                    val input = if (pending.isEmpty()) buf.copyOf(n) else pending + buf.copyOf(n)
+                    val inBuf = ByteBuffer.wrap(input)
+                    charBuf.clear()
+                    decoder.decode(inBuf, charBuf, false)
+                    pending = if (inBuf.hasRemaining()) {
+                        ByteArray(inBuf.remaining()).also { inBuf.get(it) }
+                    } else ByteArray(0)
+                    charBuf.flip()
+                    if (!charBuf.hasRemaining()) continue
+                    val chunk = charBuf.toString()
                     if (streamMode) {
                         onLine(chunk)
                     } else {
@@ -90,6 +110,15 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
                             lineBuffer.append(text.substring(lastNl + 1))
                         }
                     }
+                }
+                // Flush any bytes that form a valid sequence at end-of-stream
+                charBuf.clear()
+                decoder.decode(ByteBuffer.wrap(pending), charBuf, true)
+                decoder.flush(charBuf)
+                charBuf.flip()
+                if (charBuf.hasRemaining()) {
+                    val tail = charBuf.toString()
+                    if (streamMode) onLine(tail) else lineBuffer.append(tail)
                 }
                 if (!streamMode && lineBuffer.isNotEmpty()) {
                     onLine(lineBuffer.toString())

--- a/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
@@ -1,0 +1,127 @@
+package net.hlan.sushi
+
+import android.content.Context
+
+class LocalShellBackend(private val context: Context) : TerminalBackend {
+    private var nativeHandle: Long = 0L
+    private var readerThread: Thread? = null
+
+    override fun connect(
+        onLine: (String) -> Unit,
+        streamMode: Boolean,
+        onConnectionClosed: (() -> Unit)?,
+    ): SshConnectResult {
+        val shell = System.getenv("SHELL").takeUnless { it.isNullOrBlank() }
+            ?: "/system/bin/sh"
+        val handle = nativeStart(shell, arrayOf(shell, "-i"), defaultEnv())
+        if (handle == 0L) {
+            return SshConnectResult(false, "PTY allocation failed")
+        }
+        nativeHandle = handle
+        startReader(onLine, streamMode, onConnectionClosed)
+        return SshConnectResult(true, "Connected to local shell")
+    }
+
+    override fun isConnected(): Boolean = nativeHandle != 0L
+
+    override fun sendText(text: String): SshCommandResult {
+        val h = nativeHandle
+        if (h == 0L) return SshCommandResult(false, null, "Not connected")
+        if (text.isEmpty()) return SshCommandResult(true, null, "No input")
+        return runCatching {
+            val n = nativeWrite(h, text.toByteArray(Charsets.UTF_8))
+            if (n < 0) SshCommandResult(false, null, "Write failed")
+            else SshCommandResult(true, null, "Input sent")
+        }.getOrElse { e ->
+            SshCommandResult(false, null, e.message ?: "Write error")
+        }
+    }
+
+    override fun sendCommand(command: String): SshCommandResult {
+        val payload = if (command.endsWith("\n")) command else "$command\n"
+        return sendText(payload)
+    }
+
+    override fun sendCtrlC() {
+        val h = nativeHandle
+        if (h != 0L) runCatching { nativeWrite(h, byteArrayOf(3)) }
+    }
+
+    override fun sendCtrlD() {
+        val h = nativeHandle
+        if (h != 0L) runCatching { nativeWrite(h, byteArrayOf(4)) }
+    }
+
+    override fun resizePty(col: Int, row: Int, widthPx: Int, heightPx: Int) {
+        val h = nativeHandle
+        if (h != 0L) runCatching { nativeResize(h, col, row, widthPx, heightPx) }
+    }
+
+    override fun disconnect() {
+        val h = nativeHandle
+        nativeHandle = 0L
+        if (h != 0L) runCatching { nativeClose(h) }
+        readerThread = null
+    }
+
+    private fun startReader(
+        onLine: (String) -> Unit,
+        streamMode: Boolean,
+        onConnectionClosed: (() -> Unit)?,
+    ) {
+        val h = nativeHandle
+        readerThread = Thread {
+            val buf = ByteArray(4096)
+            val lineBuffer = StringBuilder()
+            try {
+                while (true) {
+                    val n = nativeRead(h, buf)
+                    if (n <= 0) break
+                    val chunk = String(buf, 0, n, Charsets.UTF_8)
+                    if (streamMode) {
+                        onLine(chunk)
+                    } else {
+                        lineBuffer.append(chunk)
+                        val text = lineBuffer.toString()
+                        val lastNl = text.lastIndexOf('\n')
+                        if (lastNl >= 0) {
+                            onLine(text.substring(0, lastNl + 1))
+                            lineBuffer.setLength(0)
+                            lineBuffer.append(text.substring(lastNl + 1))
+                        }
+                    }
+                }
+                if (!streamMode && lineBuffer.isNotEmpty()) {
+                    onLine(lineBuffer.toString())
+                }
+            } finally {
+                onConnectionClosed?.invoke()
+            }
+        }.apply {
+            isDaemon = true
+            name = "LocalShellReader"
+            start()
+        }
+    }
+
+    private fun defaultEnv(): Array<String> = listOf(
+        "HOME=${System.getenv("HOME") ?: context.filesDir.absolutePath}",
+        "PATH=${System.getenv("PATH") ?: "/system/bin:/system/xbin"}",
+        "ANDROID_DATA=${System.getenv("ANDROID_DATA") ?: "/data"}",
+        "ANDROID_ROOT=${System.getenv("ANDROID_ROOT") ?: "/system"}",
+        "TMPDIR=${context.cacheDir.absolutePath}",
+        "TERM=xterm-256color",
+    ).toTypedArray()
+
+    companion object {
+        init {
+            System.loadLibrary("sushi-pty")
+        }
+
+        @JvmStatic external fun nativeStart(cmd: String, argv: Array<String>, envp: Array<String>): Long
+        @JvmStatic external fun nativeRead(handle: Long, buf: ByteArray): Int
+        @JvmStatic external fun nativeWrite(handle: Long, data: ByteArray): Int
+        @JvmStatic external fun nativeResize(handle: Long, col: Int, row: Int, widthPx: Int, heightPx: Int)
+        @JvmStatic external fun nativeClose(handle: Long)
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
@@ -3,6 +3,7 @@ package net.hlan.sushi
 import android.content.Context
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
+import java.nio.charset.CharsetDecoder
 import java.nio.charset.CodingErrorAction
 
 class LocalShellBackend(private val context: Context) : TerminalBackend {
@@ -88,41 +89,11 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
                 while (true) {
                     val n = nativeRead(h, buf)
                     if (n <= 0) break
-                    val input = if (pending.isEmpty()) buf.copyOf(n) else pending + buf.copyOf(n)
-                    val inBuf = ByteBuffer.wrap(input)
-                    charBuf.clear()
-                    decoder.decode(inBuf, charBuf, false)
-                    pending = if (inBuf.hasRemaining()) {
-                        ByteArray(inBuf.remaining()).also { inBuf.get(it) }
-                    } else ByteArray(0)
-                    charBuf.flip()
+                    pending = decodeIntoBuffer(pending, buf, n, decoder, charBuf)
                     if (!charBuf.hasRemaining()) continue
-                    val chunk = charBuf.toString()
-                    if (streamMode) {
-                        onLine(chunk)
-                    } else {
-                        lineBuffer.append(chunk)
-                        val text = lineBuffer.toString()
-                        val lastNl = text.lastIndexOf('\n')
-                        if (lastNl >= 0) {
-                            onLine(text.substring(0, lastNl + 1))
-                            lineBuffer.setLength(0)
-                            lineBuffer.append(text.substring(lastNl + 1))
-                        }
-                    }
+                    dispatchOutput(charBuf.toString(), streamMode, lineBuffer, onLine)
                 }
-                // Flush any bytes that form a valid sequence at end-of-stream
-                charBuf.clear()
-                decoder.decode(ByteBuffer.wrap(pending), charBuf, true)
-                decoder.flush(charBuf)
-                charBuf.flip()
-                if (charBuf.hasRemaining()) {
-                    val tail = charBuf.toString()
-                    if (streamMode) onLine(tail) else lineBuffer.append(tail)
-                }
-                if (!streamMode && lineBuffer.isNotEmpty()) {
-                    onLine(lineBuffer.toString())
-                }
+                flushDecoder(pending, decoder, charBuf, streamMode, lineBuffer, onLine)
             } finally {
                 onConnectionClosed?.invoke()
             }
@@ -130,6 +101,62 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
             isDaemon = true
             name = "LocalShellReader"
             start()
+        }
+    }
+
+    private fun decodeIntoBuffer(
+        pending: ByteArray,
+        buf: ByteArray,
+        n: Int,
+        decoder: CharsetDecoder,
+        charBuf: CharBuffer,
+    ): ByteArray {
+        val input = if (pending.isEmpty()) buf.copyOf(n) else pending + buf.copyOf(n)
+        val inBuf = ByteBuffer.wrap(input)
+        charBuf.clear()
+        decoder.decode(inBuf, charBuf, false)
+        charBuf.flip()
+        return if (inBuf.hasRemaining()) ByteArray(inBuf.remaining()).also { inBuf.get(it) } else ByteArray(0)
+    }
+
+    private fun dispatchOutput(
+        chunk: String,
+        streamMode: Boolean,
+        lineBuffer: StringBuilder,
+        onLine: (String) -> Unit,
+    ) {
+        if (streamMode) {
+            onLine(chunk)
+        } else {
+            lineBuffer.append(chunk)
+            val text = lineBuffer.toString()
+            val lastNl = text.lastIndexOf('\n')
+            if (lastNl >= 0) {
+                onLine(text.substring(0, lastNl + 1))
+                lineBuffer.setLength(0)
+                lineBuffer.append(text.substring(lastNl + 1))
+            }
+        }
+    }
+
+    private fun flushDecoder(
+        pending: ByteArray,
+        decoder: CharsetDecoder,
+        charBuf: CharBuffer,
+        streamMode: Boolean,
+        lineBuffer: StringBuilder,
+        onLine: (String) -> Unit,
+    ) {
+        charBuf.clear()
+        decoder.decode(ByteBuffer.wrap(pending), charBuf, true)
+        decoder.flush(charBuf)
+        charBuf.flip()
+        if (charBuf.hasRemaining()) {
+            val tail = charBuf.toString()
+            if (streamMode) onLine(tail) else lineBuffer.append(tail)
+        }
+        if (!streamMode && lineBuffer.isNotEmpty()) {
+            onLine(lineBuffer.toString())
         }
     }
 

--- a/app/src/main/java/net/hlan/sushi/SshClient.kt
+++ b/app/src/main/java/net/hlan/sushi/SshClient.kt
@@ -11,6 +11,8 @@ import java.io.InputStreamReader
 import java.io.OutputStream
 import java.util.concurrent.atomic.AtomicReference
 
+enum class HostKind { SSH, LOCAL }
+
 enum class SshAuthPreference(val value: String) {
     AUTO("auto"),
     PASSWORD("password"),
@@ -24,6 +26,7 @@ enum class SshAuthPreference(val value: String) {
 }
 
 data class SshConnectionConfig(
+    val kind: HostKind = HostKind.SSH,
     val id: String = java.util.UUID.randomUUID().toString(),
     val alias: String = "",
     val host: String,
@@ -45,10 +48,14 @@ data class SshConnectionConfig(
 
     fun resolvedAuthPreference(): SshAuthPreference = SshAuthPreference.from(authPreference)
 
-    fun displayTarget(): String = if (alias.isNotBlank()) {
-        "$alias ($username@$host:$port)"
-    } else {
-        "$username@$host:$port"
+    fun displayTarget(): String {
+        val core = when {
+            kind == HostKind.LOCAL -> alias.ifBlank { "Local shell" }
+            alias.isNotBlank() -> "$alias ($username@$host:$port)"
+            else -> "$username@$host:$port"
+        }
+        val kindLabel = if (kind == HostKind.LOCAL) "local" else "ssh"
+        return "$core · $kindLabel"
     }
 }
 

--- a/app/src/main/java/net/hlan/sushi/SshSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/SshSettings.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
-class SshSettings(context: Context) {
+class SshSettings(private val context: Context) {
     private val prefs = SecurePrefs.get(context)
     private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     private val listType = Types.newParameterizedType(List::class.java, SshConnectionConfig::class.java)
@@ -109,6 +109,19 @@ class SshSettings(context: Context) {
             jumpUsername = jumpHostConfig.username,
             jumpPassword = jumpHostConfig.password
         )
+    }
+
+    fun seedLocalHostIfMissing() {
+        if (getHosts().any { it.kind == HostKind.LOCAL }) return
+        val local = SshConnectionConfig(
+            kind = HostKind.LOCAL,
+            alias = context.getString(R.string.local_shell_default_alias),
+            host = "",
+            port = 0,
+            username = "",
+            password = "",
+        )
+        saveHost(local)
     }
 
     // Migration function for old settings

--- a/app/src/main/java/net/hlan/sushi/SushiApplication.kt
+++ b/app/src/main/java/net/hlan/sushi/SushiApplication.kt
@@ -6,5 +6,6 @@ class SushiApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         AppThemeSettings(this).applyThemeMode()
+        SshSettings(this).seedLocalHostIfMissing()
     }
 }

--- a/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
@@ -124,11 +124,16 @@ class TerminalActivity : AppCompatActivity() {
         binding.terminalOutputText.appendLog(getString(R.string.terminal_connect_attempt_log))
 
         lifecycleScope.launch(Dispatchers.IO) {
-            val firstAttempt = connectWithClient(config)
+            val backend: TerminalBackend = when (config.kind) {
+                HostKind.LOCAL -> LocalShellBackend(applicationContext)
+                HostKind.SSH -> SshClient(config)
+            }
+
+            val firstAttempt = connectWith(backend, config)
             var client = firstAttempt.first
             var result = firstAttempt.second
 
-            if (!result.success) {
+            if (!result.success && config.kind == HostKind.SSH) {
                 withContext(Dispatchers.Main) {
                     isRetrying = true
                     updateUi()
@@ -139,7 +144,8 @@ class TerminalActivity : AppCompatActivity() {
 
                 delay(CONNECT_RETRY_DELAY_MS)
 
-                val secondAttempt = connectWithClient(config)
+                val retryBackend: TerminalBackend = SshClient(config)
+                val secondAttempt = connectWith(retryBackend, config)
                 client = secondAttempt.first
                 result = secondAttempt.second
             }
@@ -287,9 +293,8 @@ class TerminalActivity : AppCompatActivity() {
         binding.terminalPhrasesButton.isEnabled = canInput
     }
 
-    private fun connectWithClient(config: SshConnectionConfig): Pair<TerminalBackend, SshConnectResult> {
-        val client: TerminalBackend = SshClient(config)
-        val result = client.connect(
+    private fun connectWith(backend: TerminalBackend, config: SshConnectionConfig): Pair<TerminalBackend, SshConnectResult> {
+        val result = backend.connect(
             streamMode = true,
             onLine = { line ->
                 runOnUiThread {
@@ -304,7 +309,7 @@ class TerminalActivity : AppCompatActivity() {
                 }
             }
         )
-        return client to result
+        return backend to result
     }
 
     private fun showPhrasePicker() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="jump_required_selection">Select a jump server from the host list.</string>
     <string name="jump_invalid_port">Jump server port must be a number. Using 22.</string>
     <string name="ssh_missing_config">Add SSH details in Settings to connect.</string>
+    <string name="local_shell_default_alias">Local shell</string>
     <string name="ssh_invalid_port">Port must be a number. Using 22.</string>
     
     <string name="action_manage_hosts">Manage Hosts</string>


### PR DESCRIPTION
## Summary

Branch 2 of 3 in the v0.6.0 local-shell roadmap. Adds a real PTY-backed local shell that appears as just another host in the existing host list. `vi`, `top`, `less`, `nano`, `watch` all work because we allocate a master/slave PTY pair via `forkpty(3)` in native code — no Termux, no GPL dependency.

- **`HostKind` discriminator** — `enum class HostKind { SSH, LOCAL }` added to `SshClient.kt`; `SshConnectionConfig` gains `kind: HostKind = HostKind.SSH` as first field (Moshi's `KotlinJsonAdapterFactory` honours the Kotlin default, so old JSON deserialises as SSH with no schema bump). `displayTarget()` gains a `· ssh` / `· local` suffix so every existing caller (connect-button, log lines) shows the right label automatically.
- **Synthetic Local host** — `SshSettings` stores its `Context` and gains `seedLocalHostIfMissing()`. `SushiApplication.onCreate()` calls it so the Local shell host exists before any Activity starts.
- **`HostEditActivity`** — when `kind == LOCAL`: SSH fields hidden, Delete button hidden, host+username validation skipped, `kind` preserved on save. Jump-server dropdown filters out LOCAL hosts.
- **`libsushi-pty.so`** — `app/src/main/cpp/sushi-pty.c` (~160 LOC C): `forkpty`, `FD_CLOEXEC`, `EINTR`-safe read/write loops, `TIOCSWINSZ` resize, `SIGHUP`+`waitpid` close. `CMakeLists.txt` links against `log`. `build.gradle.kts` wires NDK 27.0.12077973, cmake path, `abiFilters` arm64-v8a + armeabi-v7a + x86_64.
- **`LocalShellBackend.kt`** — implements `TerminalBackend`; mirrors `SshClient` threading style (daemon `Thread` named `LocalShellReader`, `runCatching` cleanup). Env allowlist: HOME, PATH, ANDROID_DATA, ANDROID_ROOT, TMPDIR, TERM=xterm-256color.
- **`TerminalActivity`** — `connectTerminal()` selects backend by `config.kind`; retry loop is SSH-only; `connectWithClient` renamed to `connectWith(backend, config)`.
- **ProGuard** — `-keepclasseswithmembernames` for native methods; `-keep class net.hlan.sushi.LocalShellBackend`.

## Test plan

- [ ] `./gradlew assembleDebug` — builds without NDK errors; `libsushi-pty.so` present in APK for all three ABIs
- [ ] `./gradlew assembleRelease` — minified build loads `libsushi-pty.so` cleanly (ProGuard keep rules)
- [ ] Fresh install: "Local shell" host appears in host list automatically
- [ ] Select Local shell → TerminalActivity → Start session: PTY opens, shell prompt appears
- [ ] Type commands: `ls /`, `echo $TERM` (→ `xterm-256color`), `vi` (opens, keys work)
- [ ] Ctrl-C / Ctrl-D work; resize window → shell reflows
- [ ] Disconnect → reconnect Local shell works
- [ ] Existing SSH hosts unaffected: connect, send command, disconnect regression test
- [ ] HostEditActivity: Local shell shows only alias field; Delete hidden; alias rename persists
- [ ] Old SSH host JSON (without `kind` field) loads correctly as SSH host
- [ ] `./scripts/run-device-qa-suite.sh` clean

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s)_