### PR TITLE
Simplify SSH settings UI and auto-connect on host selection

### DIFF
--- a/app/src/androidTest/java/net/hlan/sushi/DeviceQaSuiteTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/DeviceQaSuiteTest.kt
@@ -61,13 +61,13 @@ class DeviceQaSuiteTest {
             onView(withId(R.id.mainSettingsButton)).check(matches(isDisplayed()))
         }
 
-        // SettingsActivity — verify title and SSH page buttons
+        // SettingsActivity — verify title and SSH page generate-key button
         launchActivity(SettingsActivity::class.java).use { scenario ->
             onView(withId(R.id.settingsTitle))
                 .check(matches(withText(not(isEmptyOrNullString()))))
             onView(withText("SSH")).perform(click())
-            scrollIntoView(scenario, R.id.manageHostsButton)
-            onView(withId(R.id.manageHostsButton)).check(matches(isDisplayed()))
+            scrollIntoView(scenario, R.id.quickGenerateKeyButton)
+            onView(withId(R.id.quickGenerateKeyButton)).check(matches(isDisplayed()))
         }
 
         // HostsActivity — verify title and FAB

--- a/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/HostEditActivity.kt
@@ -110,9 +110,6 @@ class HostEditActivity : AppCompatActivity() {
             buildSshConfig(alias) ?: return
         }
         sshSettings.saveHost(config)
-        if (sshSettings.getActiveHostId() == null) {
-            sshSettings.setActiveHostId(config.id)
-        }
         Toast.makeText(this, getString(R.string.settings_saved), Toast.LENGTH_SHORT).show()
         finish()
     }

--- a/app/src/main/java/net/hlan/sushi/HostsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/HostsActivity.kt
@@ -20,6 +20,7 @@ class HostsActivity : AppCompatActivity() {
         adapter = HostAdapter(
             onHostClick = { host ->
                 sshSettings.setActiveHostId(host.id)
+                startActivity(TerminalActivity.createIntent(this, autoConnect = true))
                 finish()
             },
             onEditClick = { host ->

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -196,14 +196,6 @@ class SettingsActivity : AppCompatActivity() {
     private fun setupSshPage(pageBinding: PageSettingsSshBinding) {
         sshPageBinding = pageBinding
 
-        pageBinding.manageHostsButton.setOnClickListener {
-            startActivity(Intent(this, HostsActivity::class.java))
-        }
-
-        pageBinding.quickAddHostButton.setOnClickListener {
-            startActivity(Intent(this, HostEditActivity::class.java))
-        }
-
         pageBinding.quickGenerateKeyButton.setOnClickListener {
             val hasKey = sshSettings.getPrivateKey().orEmpty().isNotBlank()
             val intent = Intent(this, KeysActivity::class.java)

--- a/app/src/main/res/layout/page_settings_ssh.xml
+++ b/app/src/main/res/layout/page_settings_ssh.xml
@@ -185,42 +185,14 @@
             android:layout_marginTop="16dp"
             android:text="@string/settings_hosts_keys_title" />
 
-        <LinearLayout
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/quickGenerateKeyButton"
+            style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:orientation="horizontal">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/quickAddHostButton"
-                style="@style/Widget.Material3.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/action_add_host"
-                app:icon="@drawable/ic_add"
-                app:iconGravity="textStart" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/quickGenerateKeyButton"
-                style="@style/Widget.Material3.Button.OutlinedButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_weight="1"
-                android:text="@string/action_generate_key_quick"
-                app:icon="@drawable/ic_vpn_key"
-                app:iconGravity="textStart" />
-        </LinearLayout>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/manageHostsButton"
-            style="@style/Widget.Sushi.PrimaryButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/action_hosts"
-            app:icon="@drawable/ic_dns"
+            android:text="@string/action_generate_key_quick"
+            app:icon="@drawable/ic_vpn_key"
             app:iconGravity="textStart" />
 
     </LinearLayout>


### PR DESCRIPTION
## Summary

This PR streamlines the SSH settings page by removing redundant quick-action buttons and improves the host selection flow by automatically connecting when a host is selected from the hosts list.

## Changes

- **Layout**: Removed the "Add Host" button and "Manage Hosts" button from the SSH settings page, keeping only the "Generate Key" button
- **HostsActivity**: Added auto-connect functionality when a host is selected (navigates to TerminalActivity with autoConnect=true)
- **HostEditActivity**: Removed automatic active host assignment when saving a new host (allows users to explicitly choose their active host)
- **SettingsActivity**: Removed click listeners for the deleted buttons
- **Tests**: Updated QA suite test to verify the remaining "Generate Key" button instead of the removed "Manage Hosts" button

## UI / UX changes

- [x] Yes — Figma frame linked below
- **Figma frame:** N/A

**Changes:**
- SSH settings page now shows only the "Generate Key" button under the "Host Keys" section
- Selecting a host from the hosts list now automatically initiates a connection
- Removed the "Add Host" quick action from settings (users can still access host management via the dedicated Hosts activity)

## Test plan

- [x] Existing tests updated to reflect UI changes
- [x] No regressions in existing flows (host selection and key generation paths remain functional)

## Checklist

- [x] No user-visible strings added/removed (only button removals)
- [x] No hardcoded secrets
- [x] No new reflection-loaded classes

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s