### PR TITLE
Add play parameter defaults, descriptions, and live preview UI

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -51,7 +51,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run-device-tests')
 
-    runs-on: [self-hosted, Linux, ARM64, android-device]
+    runs-on: [self-hosted, Linux, ARM64, RPi5, usb-android-attached]
 
     steps:
       - name: Checkout

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -2,24 +2,36 @@ name: Device Tests (RPi5 + Nokia 4.2G)
 
 # Optional workflow — never blocks PR merges.
 #
+# The runner is a Docker container (github-runner-arm64) that cannot access USB
+# directly. ADB connectivity is achieved via the host's ADB server:
+#
+#   One-time host setup on ergo (RPi5):
+#     sudo apt install adb
+#     adb start-server          # starts host ADB daemon
+#     adb devices               # confirm Nokia appears
+#   The container connects to the host daemon via the Docker bridge (172.17.0.1:5037
+#   by default, or host.docker.internal on Docker Desktop).
+#   Set ANDROID_ADB_SERVER_ADDRESS and ANDROID_ADB_SERVER_PORT as runner env vars
+#   in the container, or let the workflow use the defaults below.
+#
+#   Alternative — ADB over Wi-Fi (no USB passthrough needed either way):
+#     adb tcpip 5555            # run once while phone is USB-connected to host
+#     adb connect <nokia-ip>:5555
+#   Then set secret ANDROID_DEVICE_ADDRESS = <nokia-ip>:5555
+#
 # Triggers:
 #   1. Manual dispatch from the GitHub Actions UI (any branch).
 #   2. Automatically when the "run-device-tests" label is added to a PR.
-#
-# Runner requirements (pre-installed on the RPi5 self-hosted runner):
-#   - JDK 17  (e.g. sudo apt install openjdk-17-jdk)
-#   - Android SDK command-line tools with platform android-36 and build-tools
-#   - ADB in PATH; Nokia 4.2G authorised for USB debug
 
 on:
   workflow_dispatch:
     inputs:
       test_class:
-        description: "Specific test class to run (empty = full DeviceQaSuiteTest)"
+        description: "Test class (empty = full DeviceQaSuiteTest)"
         required: false
         default: ""
       branch:
-        description: "Branch to test (defaults to the branch you run this from)"
+        description: "Branch to test (empty = current ref)"
         required: false
         default: ""
 
@@ -29,13 +41,12 @@ on:
 
 permissions:
   contents: read
-  checks: write        # allows posting test results as a check annotation
-  pull-requests: write # allows commenting the result summary on the PR
+  checks: write
+  pull-requests: write
 
 jobs:
   device-test:
     name: Instrumented tests on Nokia 4.2G
-    # Only run for the label trigger when the right label was added.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run-device-tests')
@@ -48,15 +59,38 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - name: Verify ADB device connected
+      - name: Connect to ADB (host server or Wi-Fi)
+        env:
+          # Host ADB server — reachable from inside the Docker container via the
+          # Docker bridge address. Override with runner env vars if the bridge IP
+          # differs on your setup.
+          ADB_HOST: ${{ vars.ADB_SERVER_HOST || '172.17.0.1' }}
+          ADB_PORT: ${{ vars.ADB_SERVER_PORT || '5037' }}
+          # Optional: explicit device address for Wi-Fi ADB (e.g. "192.168.1.42:5555").
+          # When set, the step connects via TCP instead of relying on the host server.
+          DEVICE_ADDRESS: ${{ secrets.ANDROID_DEVICE_ADDRESS }}
         run: |
+          export ANDROID_ADB_SERVER_ADDRESS="$ADB_HOST"
+          export ANDROID_ADB_SERVER_PORT="$ADB_PORT"
+
+          if [ -n "$DEVICE_ADDRESS" ]; then
+            echo "Connecting to device at $DEVICE_ADDRESS via TCP..."
+            adb connect "$DEVICE_ADDRESS"
+          fi
+
           adb devices -l
+
           DEVICE_COUNT=$(adb devices | grep -v "^List" | grep "device$" | wc -l)
           if [ "$DEVICE_COUNT" -eq 0 ]; then
-            echo "::error::No Android device found via ADB. Check USB connection and authorisation."
+            echo "::error::No Android device found. Check USB/Wi-Fi connection, ADB authorisation, and that the host ADB server is running (adb start-server on ergo)."
             exit 1
           fi
-          echo "Found $DEVICE_COUNT device(s)"
+          echo "Found $DEVICE_COUNT device(s) — continuing."
+
+          # Persist ADB env for subsequent steps.
+          echo "ANDROID_ADB_SERVER_ADDRESS=$ADB_HOST" >> "$GITHUB_ENV"
+          echo "ANDROID_ADB_SERVER_PORT=$ADB_PORT"    >> "$GITHUB_ENV"
+          [ -n "$DEVICE_ADDRESS" ] && echo "ANDROID_SERIAL=$DEVICE_ADDRESS" >> "$GITHUB_ENV" || true
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -72,9 +106,7 @@ jobs:
           else
             CLASS_ARG="-Pandroid.testInstrumentationRunnerArguments.class=net.hlan.sushi.DeviceQaSuiteTest"
           fi
-          ./gradlew connectedDebugAndroidTest $CLASS_ARG \
-            --continue \
-            2>&1 | tee test-output.txt
+          ./gradlew connectedDebugAndroidTest $CLASS_ARG --continue 2>&1 | tee test-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Upload test results
@@ -93,12 +125,13 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const exitCode = '${{ steps.run_tests.outputs.exit_code }}';
-            const passed = exitCode === '0';
+            const passed = '${{ steps.run_tests.outputs.exit_code }}' === '0';
             const icon = passed ? '✅' : '❌';
             const body = `### ${icon} Device Tests — Nokia 4.2G (RPi5 runner)
 
-            ${passed ? 'All instrumented tests passed.' : 'One or more tests failed — see the [test artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'}
+            ${passed
+              ? 'All instrumented tests passed.'
+              : 'One or more tests failed — see the [test artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'}
 
             _Triggered by label \`run-device-tests\` on this PR._`;
 
@@ -107,11 +140,9 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-
             const existing = comments.find(c =>
               c.user.type === 'Bot' && c.body.includes('Device Tests — Nokia 4.2G')
             );
-
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -51,7 +51,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run-device-tests')
 
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, ARM64, android-device]
 
     steps:
       - name: Checkout

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -1,0 +1,133 @@
+name: Device Tests (RPi5 + Nokia 4.2G)
+
+# Optional workflow — never blocks PR merges.
+#
+# Triggers:
+#   1. Manual dispatch from the GitHub Actions UI (any branch).
+#   2. Automatically when the "run-device-tests" label is added to a PR.
+#
+# Runner requirements (pre-installed on the RPi5 self-hosted runner):
+#   - JDK 17  (e.g. sudo apt install openjdk-17-jdk)
+#   - Android SDK command-line tools with platform android-36 and build-tools
+#   - ADB in PATH; Nokia 4.2G authorised for USB debug
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_class:
+        description: "Specific test class to run (empty = full DeviceQaSuiteTest)"
+        required: false
+        default: ""
+      branch:
+        description: "Branch to test (defaults to the branch you run this from)"
+        required: false
+        default: ""
+
+  pull_request:
+    branches: ["main"]
+    types: [labeled]
+
+permissions:
+  contents: read
+  checks: write        # allows posting test results as a check annotation
+  pull-requests: write # allows commenting the result summary on the PR
+
+jobs:
+  device-test:
+    name: Instrumented tests on Nokia 4.2G
+    # Only run for the label trigger when the right label was added.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'run-device-tests')
+
+    runs-on: [self-hosted, android-device]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Verify ADB device connected
+        run: |
+          adb devices -l
+          DEVICE_COUNT=$(adb devices | grep -v "^List" | grep "device$" | wc -l)
+          if [ "$DEVICE_COUNT" -eq 0 ]; then
+            echo "::error::No Android device found via ADB. Check USB connection and authorisation."
+            exit 1
+          fi
+          echo "Found $DEVICE_COUNT device(s)"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build instrumented test APK
+        run: ./gradlew assembleDebug assembleDebugAndroidTest
+
+      - name: Run instrumented tests
+        id: run_tests
+        run: |
+          if [ -n "${{ github.event.inputs.test_class }}" ]; then
+            CLASS_ARG="-Pandroid.testInstrumentationRunnerArguments.class=${{ github.event.inputs.test_class }}"
+          else
+            CLASS_ARG="-Pandroid.testInstrumentationRunnerArguments.class=net.hlan.sushi.DeviceQaSuiteTest"
+          fi
+          ./gradlew connectedDebugAndroidTest $CLASS_ARG \
+            --continue \
+            2>&1 | tee test-output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-test-results-${{ github.run_number }}
+          path: |
+            app/build/reports/androidTests/
+            app/build/outputs/androidTest-results/
+            test-output.txt
+          retention-days: 14
+
+      - name: Post result comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const exitCode = '${{ steps.run_tests.outputs.exit_code }}';
+            const passed = exitCode === '0';
+            const icon = passed ? '✅' : '❌';
+            const body = `### ${icon} Device Tests — Nokia 4.2G (RPi5 runner)
+
+            ${passed ? 'All instrumented tests passed.' : 'One or more tests failed — see the [test artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'}
+
+            _Triggered by label \`run-device-tests\` on this PR._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Device Tests — Nokia 4.2G')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail job if tests failed
+        if: steps.run_tests.outputs.exit_code != '0'
+        run: exit 1

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -51,7 +51,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run-device-tests')
 
-    runs-on: [self-hosted, android-device]
+    runs-on: [self-hosted, Linux, ARM64]
 
     steps:
       - name: Checkout

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -540,7 +540,7 @@ class MainActivity : AppCompatActivity() {
             .setTitle(R.string.plays_title)
             .setItems(playNames) { _, which ->
                 val play = plays[which]
-                promptPlayParametersAndRun(play, host)
+                promptPlayParametersAndRun(play, host, onBack = { showPlaySelectionDialog(plays, host) })
             }
             .setPositiveButton(R.string.action_manage) { _, _ ->
                 startActivity(Intent(this, PlaysActivity::class.java))
@@ -549,7 +549,11 @@ class MainActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun promptPlayParametersAndRun(play: Play, host: SshConnectionConfig) {
+    private fun promptPlayParametersAndRun(
+        play: Play,
+        host: SshConnectionConfig,
+        onBack: (() -> Unit)? = null
+    ) {
         val parameters = PlayParameters.decode(play.parametersJson).ifEmpty {
             PlayParameters.inferFromTemplate(play.scriptTemplate)
         }
@@ -559,31 +563,79 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
+        val dp = resources.displayMetrics.density
+        val pad = (16 * dp).toInt()
+        val smallGap = (8 * dp).toInt()
+
         val container = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(32, 16, 32, 0)
+            setPadding(pad, smallGap, pad, 0)
         }
+
+        // Live command preview
+        val previewView = android.widget.TextView(this).apply {
+            typeface = android.graphics.Typeface.MONOSPACE
+            setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodySmall)
+            setBackgroundColor(
+                android.graphics.Color.argb(20, 128, 128, 128)
+            )
+            setPadding(smallGap, smallGap, smallGap, smallGap)
+            text = play.scriptTemplate
+        }
+        container.addView(previewView, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ).also { it.bottomMargin = smallGap })
+
         val fields = linkedMapOf<PlayParameter, TextInputEditText>()
 
         parameters.forEachIndexed { index, parameter ->
             addParameterField(container, fields, parameter, index > 0)
         }
 
+        // Helper that re-renders preview from current field values
+        fun refreshPreview() {
+            val current = fields.entries.associate { (param, input) ->
+                val typed = input.text?.toString().orEmpty()
+                param.key to typed.ifBlank { param.default.orEmpty() }.ifBlank { "…" }
+            }
+            val placeholderRegex = Regex("\\{\\{\\s*([A-Za-z0-9_]+)\\s*\\}\\}")
+            previewView.text = placeholderRegex.replace(play.scriptTemplate) { match ->
+                current[match.groupValues[1]] ?: match.value
+            }
+        }
+
+        // Attach TextWatchers after all fields are created
+        fields.values.forEach { input ->
+            input.addTextChangedListener(object : android.text.TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+                override fun afterTextChanged(s: android.text.Editable?) { refreshPreview() }
+            })
+        }
+        refreshPreview()
+
         val content = ScrollView(this).apply { addView(container) }
 
+        val negLabel = if (onBack != null) R.string.play_param_back else R.string.phrase_cancel
         val dialog = AlertDialog.Builder(this)
             .setTitle(getString(R.string.play_prompt_title, play.name))
             .setView(content)
             .setPositiveButton(R.string.action_run_play, null)
-            .setNegativeButton(R.string.phrase_cancel, null)
+            .setNegativeButton(negLabel, null)
             .create()
 
         dialog.setOnShowListener {
-            val runButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
-            runButton.setOnClickListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
                 val values = collectAndValidatePlayValues(fields) ?: return@setOnClickListener
                 dialog.dismiss()
                 runPlay(play, host, values)
+            }
+            if (onBack != null) {
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
+                    dialog.dismiss()
+                    onBack()
+                }
             }
         }
         dialog.show()
@@ -595,8 +647,16 @@ class MainActivity : AppCompatActivity() {
         parameter: PlayParameter,
         withTopMargin: Boolean
     ) {
+        val dp = resources.displayMetrics.density
+        val hint = if (parameter.required && parameter.default.isNullOrBlank()) {
+            "${parameter.label} *"
+        } else {
+            parameter.label
+        }
         val layout = TextInputLayout(this).apply {
-            hint = parameter.label
+            this.hint = hint
+            parameter.description?.let { helperText = it }
+                ?: parameter.example?.let { helperText = getString(R.string.play_param_example_prefix, it) }
         }
         val input = TextInputEditText(this).apply {
             inputType = if (parameter.secret) {
@@ -604,18 +664,15 @@ class MainActivity : AppCompatActivity() {
             } else {
                 android.text.InputType.TYPE_CLASS_TEXT
             }
+            parameter.default?.let { setText(it) }
         }
         layout.addView(input)
-        if (withTopMargin) {
-            val params = LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
-            )
-            params.topMargin = 12
-            container.addView(layout, params)
-        } else {
-            container.addView(layout)
-        }
+        val lp = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        )
+        if (withTopMargin) lp.topMargin = (12 * dp).toInt()
+        container.addView(layout, lp)
         fields[parameter] = input
     }
 
@@ -628,7 +685,8 @@ class MainActivity : AppCompatActivity() {
             val value = input.text?.toString().orEmpty()
             val layout = input.parent.parent as? TextInputLayout
             layout?.error = null
-            if (parameter.required && value.isBlank()) {
+            // Required with no value AND no default → show error (PlayRunner would also reject).
+            if (parameter.required && value.isBlank() && parameter.default.isNullOrBlank()) {
                 layout?.error = getString(R.string.play_parameter_required)
                 hasError = true
             } else {

--- a/app/src/main/java/net/hlan/sushi/Play.kt
+++ b/app/src/main/java/net/hlan/sushi/Play.kt
@@ -16,7 +16,10 @@ data class PlayParameter(
     val key: String,
     val label: String,
     val required: Boolean = true,
-    val secret: Boolean = false
+    val secret: Boolean = false,
+    val default: String? = null,
+    val description: String? = null,
+    val example: String? = null
 )
 
 object PlayParameters {
@@ -41,7 +44,10 @@ object PlayParameters {
                             key = key,
                             label = label,
                             required = item.optBoolean("required", true),
-                            secret = item.optBoolean("secret", false)
+                            secret = item.optBoolean("secret", false),
+                            default = item.optString("default").takeIf { it.isNotEmpty() },
+                            description = item.optString("description").takeIf { it.isNotEmpty() },
+                            example = item.optString("example").takeIf { it.isNotEmpty() }
                         )
                     )
                 }
@@ -57,6 +63,9 @@ object PlayParameters {
                 .put("label", parameter.label)
                 .put("required", parameter.required)
                 .put("secret", parameter.secret)
+            parameter.default?.let { obj.put("default", it) }
+            parameter.description?.let { obj.put("description", it) }
+            parameter.example?.let { obj.put("example", it) }
             array.put(obj)
         }
         return array.toString()

--- a/app/src/main/java/net/hlan/sushi/PlayDatabaseHelper.kt
+++ b/app/src/main/java/net/hlan/sushi/PlayDatabaseHelper.kt
@@ -35,7 +35,10 @@ class PlayDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        // No schema migrations yet.
+        // v1 → v2: PlayParameter gained default/description/example fields.
+        // These are stored as JSON inside parameters_json, so the column schema is
+        // unchanged — the new fields are simply absent in old rows and default to null
+        // when decoded. No ALTER TABLE needed.
     }
 
     fun getAllPlays(): List<Play> {
@@ -185,7 +188,7 @@ class PlayDatabaseHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_
     }
 
     companion object {
-        private const val DATABASE_VERSION = 1
+        private const val DATABASE_VERSION = 2
         private const val DATABASE_NAME = "sushi_plays.db"
         private const val TABLE_PLAYS = "plays"
         private const val COLUMN_ID = "id"

--- a/app/src/main/java/net/hlan/sushi/PlayRunner.kt
+++ b/app/src/main/java/net/hlan/sushi/PlayRunner.kt
@@ -37,14 +37,21 @@ object PlayRunner {
             PlayParameters.inferFromTemplate(play.scriptTemplate)
         }
 
+        // Resolve effective values: caller-supplied → parameter default → empty.
+        // Required parameters with no value (and no default) are rejected before execution.
+        val effectiveValues = parameters.associate { parameter ->
+            val supplied = values[parameter.key].orEmpty()
+            val effective = supplied.ifBlank { parameter.default.orEmpty() }
+            parameter.key to effective
+        }
+
         parameters.forEach { parameter ->
-            val value = values[parameter.key].orEmpty()
-            if (parameter.required && value.isBlank()) {
+            if (parameter.required && effectiveValues[parameter.key].isNullOrBlank()) {
                 return PlayRunResult(false, "Missing required value: ${parameter.label}")
             }
         }
 
-        val rendered = renderTemplate(play.scriptTemplate, values)
+        val rendered = renderTemplate(play.scriptTemplate, effectiveValues)
         if (rendered.isBlank()) {
             return PlayRunResult(false, "Rendered command is empty")
         }

--- a/app/src/main/res/layout/dialog_edit_play.xml
+++ b/app/src/main/res/layout/dialog_edit_play.xml
@@ -50,4 +50,13 @@
             android:lines="5" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <TextView
+        android:id="@+id/playScriptParamHint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/play_script_hint_params"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,9 @@
     <string name="play_run_failed">[Play] Failed %1$s: %2$s</string>
     <string name="play_missing_hosts">Add at least one host before running plays.</string>
     <string name="play_parameter_required">This value is required</string>
+    <string name="play_script_hint_params">Use {{ NAME }} for parameters. Example: restart {{ service }}</string>
+    <string name="play_param_example_prefix">e.g. %1$s</string>
+    <string name="play_param_back">Back</string>
     <string name="play_status_running_toast">Wait for current play to finish.</string>
     <string name="action_run_play">Run play</string>
     <string name="play_param_username">Username</string>

--- a/docs/CI_DEVICE_TESTING.md
+++ b/docs/CI_DEVICE_TESTING.md
@@ -1,0 +1,133 @@
+# CI Device Testing — RPi5 + Nokia 4.2G
+
+> **Scope note:** This infrastructure is outside the product roadmap.
+> It supports the development process but is not a user-facing feature.
+
+## Overview
+
+Instrumented Android tests run on a Nokia 4.2G connected to a Raspberry Pi 5
+(`ergo`) via USB. The GitHub Actions runner on that machine is a Docker
+container (`github-runner-arm64:2.323.0`), so the phone is not directly
+visible inside the container — ADB connectivity is bridged through the host.
+
+The workflow `.github/workflows/device-tests.yml` is **optional and never a
+required check**. It is triggered manually or by adding the label
+`run-device-tests` to a pull request.
+
+---
+
+## Current state
+
+| Layer | Status |
+|-------|--------|
+| RPi5 self-hosted runner | Running (Docker container) |
+| Nokia 4.2G USB connection | Connected to host `ergo` |
+| ADB on host | Needs to be started manually (`adb start-server`) |
+| Workflow | Committed, not yet exercised end-to-end |
+
+---
+
+## One-time host setup
+
+```bash
+# Install ADB on ergo (if not already present)
+sudo apt update && sudo apt install -y android-tools-adb
+
+# Confirm the phone is visible
+adb devices
+# → List of devices attached
+# → <serial>   device
+
+# Allow the Docker container to reach the host ADB daemon.
+# The daemon binds to 127.0.0.1:5037 by default; rebind it to the
+# Docker bridge so the container can connect.
+adb kill-server
+adb -a -P 5037 start-server
+# -a  = listen on all interfaces (including the Docker bridge 172.17.0.1)
+```
+
+> ⚠️ `adb -a start-server` exposes the daemon on 0.0.0.0. This is safe on a
+> closed home/office network but should not be done on untrusted networks.
+> Alternatively, bind only to the bridge: `ADB_SERVER_SOCKET=tcp:172.17.0.1:5037 adb start-server`
+
+---
+
+## Pending: make ADB a systemd service
+
+Running `adb start-server` manually means the daemon is lost on reboot or if
+the process crashes. The daemon should be managed by systemd so it starts
+automatically and reconnects to the phone.
+
+### Proposed unit file `/etc/systemd/system/adb-server.service`
+
+```ini
+[Unit]
+Description=Android Debug Bridge server
+After=network.target
+
+[Service]
+Type=forking
+User=larry
+# Bind to the Docker bridge so the runner container can connect.
+# Change the IP if your bridge address differs (ip -4 addr show docker0).
+Environment="ADB_SERVER_SOCKET=tcp:172.17.0.1:5037"
+ExecStart=/usr/bin/adb -a -P 5037 start-server
+ExecStop=/usr/bin/adb kill-server
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Enable and verify
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now adb-server
+sudo systemctl status adb-server
+
+# Confirm the phone is reachable from the container
+docker exec github-runner-runner-hlan-net-1 \
+  adb -H 172.17.0.1 -P 5037 devices
+```
+
+### Phone authorisation after reboot
+
+The Nokia stores the host's ADB RSA key in its authorised-keys list. As long
+as the key (`~/.android/adbkey`) on `ergo` is preserved across reboots the
+phone will not ask for re-authorisation. If the key is regenerated (e.g. after
+`adb keygen`), the phone must be physically unlocked and the prompt accepted
+again.
+
+---
+
+## Workflow configuration reference
+
+Set these once in **GitHub → Repository → Settings → Secrets and variables**:
+
+| Kind | Name | Value | Purpose |
+|------|------|-------|---------|
+| Variable | `ADB_SERVER_HOST` | `172.17.0.1` | Docker bridge IP of host ADB daemon |
+| Variable | `ADB_SERVER_PORT` | `5037` | ADB daemon port |
+| Secret | `ANDROID_DEVICE_ADDRESS` | `<nokia-ip>:5555` | Only needed for Wi-Fi ADB mode |
+
+The workflow falls back to `172.17.0.1:5037` if the variables are absent.
+
+---
+
+## Wi-Fi ADB (alternative, no USB passthrough needed)
+
+If USB passthrough becomes unreliable, the phone can be reached over Wi-Fi:
+
+```bash
+# While phone is still connected via USB:
+adb tcpip 5555
+
+# Disconnect USB, then:
+adb connect <nokia-lan-ip>:5555
+```
+
+Set `ANDROID_DEVICE_ADDRESS = <nokia-lan-ip>:5555` as a repository secret and
+the workflow will use `adb connect` automatically. Assign the phone a static
+DHCP lease on the router to keep the IP stable.


### PR DESCRIPTION
## Summary

Enhances the Play parameters system with support for default values, descriptions, and examples. Adds a live command preview in the parameter dialog that updates as users type. Also includes CI infrastructure for device testing on RPi5 + Nokia 4.2G.

## Changes

**Play Parameter Enhancements:**
- Extended `PlayParameter` data class with optional `default`, `description`, and `example` fields
- Updated JSON serialization/deserialization in `PlayParameters` to handle new fields
- Modified `PlayRunner` to resolve effective parameter values: caller-supplied → parameter default → empty
- Updated validation to allow required parameters with defaults to be submitted without user input

**UI Improvements:**
- Added live command preview in the play parameter dialog that renders the script template with current field values
- Preview updates in real-time as users type into parameter fields
- Enhanced parameter field labels to show asterisk (*) for required fields without defaults
- Added helper text display for parameter descriptions and examples
- Improved dialog button labels: "Back" when returning to play selection, "Cancel" otherwise
- Responsive padding/margins using display metrics density

**CI/Device Testing:**
- Added `.github/workflows/device-tests.yml` workflow for instrumented testing on Nokia 4.2G connected to RPi5
- Supports both USB ADB (via host daemon) and Wi-Fi ADB modes
- Triggered manually or via `run-device-tests` label on PRs
- Includes test result artifacts and PR comment reporting
- Added comprehensive documentation in `docs/CI_DEVICE_TESTING.md` with setup instructions and systemd service proposal

**Database:**
- Updated `PlayDatabaseHelper` schema version to v2 with migration notes (no ALTER TABLE needed as new fields are JSON-embedded)

**Strings:**
- Added new string resources for parameter hints, examples, and back button label

## UI / UX changes

- [x] Yes — Parameter dialog now shows live command preview and enhanced field labels
- [ ] No — purely logic/backend change

**Figma frame:** N/A

## Test plan

- [x] Tested on device / emulator
- [x] No regressions in existing flows

The play parameter dialog now displays a live preview of the rendered command, helping users understand how their inputs affect the final script. Parameter defaults are properly resolved during execution, and validation correctly handles required fields with defaults.

## Checklist

- [x] User-visible strings added to `strings.xml`
- [x] No hardcoded secrets
- [x] ProGuard rules updated if new reflection-loaded classes added (N/A)

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s