### PR TITLE
fix(deps): bump bcprov-jdk18on to 1.84, drop bcprov-ext-jdk18on

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,9 +117,8 @@ dependencies {
     implementation("com.github.mwiede:jsch:2.28.2")
     implementation("com.jcraft:jzlib:1.1.3")
     // Bouncy Castle provides Ed25519 on Android API < 33 (JCE lacks EdDSA before API 33).
-    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
-    // JSch BC integration references ML-KEM classes shipped in bcprov-ext.
-    implementation("org.bouncycastle:bcprov-ext-jdk18on:1.78.1")
+    // bcprov-ext-jdk18on was discontinued after 1.78.1; ML-KEM merged into bcprov since 1.79.
+    implementation("org.bouncycastle:bcprov-jdk18on:1.84")
     implementation("androidx.security:security-crypto:1.1.0")
     implementation("com.google.android.gms:play-services-auth:21.5.1")
     implementation("com.google.api-client:google-api-client-android:2.9.0")


### PR DESCRIPTION
## Summary

- Bumps `org.bouncycastle:bcprov-jdk18on` from 1.78.1 → 1.84
- Removes `org.bouncycastle:bcprov-ext-jdk18on` — this artifact was discontinued after 1.78.1; BouncyCastle merged ML-KEM and other PQC classes into the main `bcprov` jar starting in 1.79

## Why Dependabot PR #91 failed

Dependabot bumped both artifacts to 1.84, but `bcprov-ext-jdk18on:1.84` does not exist on Maven Central. This PR replaces #91 with the correct fix.

## Test plan

- [ ] `./gradlew assembleDebug` passes
- [ ] CI build check goes green
- [ ] Close Dependabot PR #91 after merging

🤖 Generated with [Claude Code](https://claude.ai/claude-code)