### PR TITLE
feat(gemini): persist conversation transcripts to SQLite (WS2a)

### DIFF
--- a/app/src/androidTest/java/net/hlan/sushi/GeminiTranscriptDatabaseHelperTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/GeminiTranscriptDatabaseHelperTest.kt
@@ -1,0 +1,164 @@
+package net.hlan.sushi
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for [GeminiTranscriptDatabaseHelper].
+ *
+ * SQLite ships with the device runtime, so the helper is exercised against a real on-device
+ * database file (deleted before each test for isolation).
+ */
+@RunWith(AndroidJUnit4::class)
+class GeminiTranscriptDatabaseHelperTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var helper: GeminiTranscriptDatabaseHelper
+
+    @Before
+    fun setUp() {
+        GeminiTranscriptDatabaseHelper.resetInstance()
+        context.deleteDatabase("sushi_gemini_transcripts.db")
+        helper = GeminiTranscriptDatabaseHelper.getInstance(context)
+        helper.clearAll()
+    }
+
+    @After
+    fun tearDown() {
+        helper.clearAll()
+        GeminiTranscriptDatabaseHelper.resetInstance()
+    }
+
+    @Test
+    fun appendEntry_persistsRow() {
+        val record = sampleRecord(sessionId = "s1", userMessage = "hello")
+        val id = helper.appendEntry(record)
+        assertTrue("inserted id should be positive", id > 0)
+
+        val rows = helper.getEntriesForSession("s1")
+        assertEquals(1, rows.size)
+        assertEquals("hello", rows[0].userMessage)
+        assertEquals("ack", rows[0].geminiReply)
+        assertNull(rows[0].commandExecuted)
+    }
+
+    @Test
+    fun appendEntry_storesCommandAndOutput() {
+        helper.appendEntry(
+            sampleRecord(
+                sessionId = "s1",
+                userMessage = "disk?",
+                geminiReply = "Checking",
+                commandExecuted = "df -h",
+                commandOutput = "Filesystem  Size  Used Avail Use%",
+                success = true
+            )
+        )
+        val rows = helper.getEntriesForSession("s1")
+        assertEquals("df -h", rows[0].commandExecuted)
+        assertEquals("Filesystem  Size  Used Avail Use%", rows[0].commandOutput)
+        assertTrue(rows[0].success)
+    }
+
+    @Test
+    fun getEntriesForSession_orderedByTimestampAscending() {
+        helper.appendEntry(sampleRecord(sessionId = "s1", timestamp = 200, userMessage = "second"))
+        helper.appendEntry(sampleRecord(sessionId = "s1", timestamp = 100, userMessage = "first"))
+        helper.appendEntry(sampleRecord(sessionId = "s1", timestamp = 300, userMessage = "third"))
+
+        val rows = helper.getEntriesForSession("s1")
+        assertEquals(listOf("first", "second", "third"), rows.map { it.userMessage })
+    }
+
+    @Test
+    fun getAllSessions_groupsBySessionAndOrdersByLastActivityDesc() {
+        helper.appendEntry(sampleRecord(sessionId = "older", timestamp = 100, userMessage = "old1"))
+        helper.appendEntry(sampleRecord(sessionId = "older", timestamp = 110, userMessage = "old2"))
+        helper.appendEntry(sampleRecord(sessionId = "newer", timestamp = 500, userMessage = "new1"))
+
+        val sessions = helper.getAllSessions()
+        assertEquals(listOf("newer", "older"), sessions.map { it.sessionId })
+        val older = sessions.first { it.sessionId == "older" }
+        assertEquals(2, older.turnCount)
+        assertEquals(100L, older.startedAt)
+        assertEquals(110L, older.lastActivityAt)
+        assertEquals("old1", older.firstMessage)
+    }
+
+    @Test
+    fun getAllSessions_firstMessageReflectsEarliestTurn() {
+        helper.appendEntry(sampleRecord(sessionId = "s1", timestamp = 200, userMessage = "second"))
+        helper.appendEntry(sampleRecord(sessionId = "s1", timestamp = 100, userMessage = "first"))
+
+        val summary = helper.getAllSessions().single()
+        assertEquals("first", summary.firstMessage)
+    }
+
+    @Test
+    fun deleteSession_removesAllItsEntries() {
+        helper.appendEntry(sampleRecord(sessionId = "keep"))
+        helper.appendEntry(sampleRecord(sessionId = "drop"))
+        helper.appendEntry(sampleRecord(sessionId = "drop"))
+
+        val deleted = helper.deleteSession("drop")
+        assertEquals(2, deleted)
+        assertEquals(0, helper.getEntriesForSession("drop").size)
+        assertEquals(1, helper.getEntriesForSession("keep").size)
+    }
+
+    @Test
+    fun nullableFieldsRoundTripCleanly() {
+        helper.appendEntry(
+            sampleRecord(
+                sessionId = "s1",
+                hostId = null,
+                hostLabel = null,
+                commandExecuted = null,
+                commandOutput = null
+            )
+        )
+        val row = helper.getEntriesForSession("s1").single()
+        assertNull(row.hostId)
+        assertNull(row.hostLabel)
+        assertNull(row.commandExecuted)
+        assertNull(row.commandOutput)
+    }
+
+    @Test
+    fun getInstance_returnsSameSingleton() {
+        val a = GeminiTranscriptDatabaseHelper.getInstance(context)
+        val b = GeminiTranscriptDatabaseHelper.getInstance(context)
+        assertNotNull(a)
+        assertTrue("getInstance should return the same singleton", a === b)
+    }
+
+    private fun sampleRecord(
+        sessionId: String = "s",
+        hostId: String? = "host-1",
+        hostLabel: String? = "ergo",
+        timestamp: Long = System.currentTimeMillis(),
+        userMessage: String = "hi",
+        geminiReply: String = "ack",
+        commandExecuted: String? = null,
+        commandOutput: String? = null,
+        success: Boolean = true
+    ) = GeminiTranscriptRecord(
+        sessionId = sessionId,
+        hostId = hostId,
+        hostLabel = hostLabel,
+        timestamp = timestamp,
+        userMessage = userMessage,
+        geminiReply = geminiReply,
+        commandExecuted = commandExecuted,
+        commandOutput = commandOutput,
+        success = success
+    )
+}

--- a/app/src/main/java/net/hlan/sushi/ConversationManager.kt
+++ b/app/src/main/java/net/hlan/sushi/ConversationManager.kt
@@ -17,7 +17,11 @@ class ConversationManager(
     private val backend: TerminalBackend,
     private val geminiClient: GeminiClient?,
     private val geminiNanoClient: GeminiNanoClient?,
-    private val useNano: Boolean = false
+    private val useNano: Boolean = false,
+    private val transcriptStore: GeminiTranscriptDatabaseHelper? = null,
+    private val sessionId: String = java.util.UUID.randomUUID().toString(),
+    private val hostId: String? = null,
+    private val hostLabel: String? = null
 ) {
     private val personaClient = PersonaClient(backend)
     private val conversationHistory = mutableListOf<ConversationTurn>()
@@ -298,14 +302,40 @@ Provide a natural language interpretation of this result, responding as the syst
         )
         
         conversationHistory.add(turn)
-        
+
         // Keep last 10 turns only (manage memory)
         if (conversationHistory.size > 10) {
             conversationHistory.removeAt(0)
         }
-        
+
         // Write to target-side log file
         writeToLog(turn)
+
+        // Persist to local SQLite history if a store is configured (G-6).
+        persistTurn(turn)
+    }
+
+    private suspend fun persistTurn(turn: ConversationTurn) {
+        val store = transcriptStore ?: return
+        withContext(Dispatchers.IO) {
+            runCatching {
+                store.appendEntry(
+                    GeminiTranscriptRecord(
+                        sessionId = sessionId,
+                        hostId = hostId,
+                        hostLabel = hostLabel,
+                        timestamp = turn.timestamp,
+                        userMessage = turn.userMessage,
+                        geminiReply = turn.systemResponse,
+                        commandExecuted = turn.commandExecuted,
+                        commandOutput = turn.commandOutput,
+                        success = turn.executionSuccess
+                    )
+                )
+            }.onFailure { e ->
+                Log.w(TAG, "Failed to persist transcript turn", e)
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/net/hlan/sushi/GeminiTranscriptDatabaseHelper.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiTranscriptDatabaseHelper.kt
@@ -1,0 +1,222 @@
+package net.hlan.sushi
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * SQLite-backed store for Gemini conversation transcripts.
+ *
+ * One row per turn (user message + Gemini reply, optionally with executed command + output).
+ * Rows are grouped by [GeminiTranscriptRecord.sessionId] so the history UI can list distinct
+ * sessions. The reactive [sessionsFlow] surfaces an up-to-date session list to observers.
+ */
+class GeminiTranscriptDatabaseHelper(context: Context) :
+    SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+
+    private val _sessionsFlow = MutableStateFlow<List<GeminiTranscriptSessionSummary>>(emptyList())
+    val sessionsFlow: Flow<List<GeminiTranscriptSessionSummary>> = _sessionsFlow.asStateFlow()
+
+    init {
+        CoroutineScope(Dispatchers.IO).launch {
+            refreshSessionsFlow()
+        }
+    }
+
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE $TABLE (
+                $COL_ID INTEGER PRIMARY KEY AUTOINCREMENT,
+                $COL_SESSION_ID TEXT NOT NULL,
+                $COL_HOST_ID TEXT,
+                $COL_HOST_LABEL TEXT,
+                $COL_TIMESTAMP INTEGER NOT NULL,
+                $COL_USER_MESSAGE TEXT NOT NULL,
+                $COL_GEMINI_REPLY TEXT NOT NULL,
+                $COL_COMMAND_EXECUTED TEXT,
+                $COL_COMMAND_OUTPUT TEXT,
+                $COL_SUCCESS INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX idx_session ON $TABLE($COL_SESSION_ID)")
+        db.execSQL("CREATE INDEX idx_timestamp ON $TABLE($COL_TIMESTAMP)")
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        // First version — no migrations yet.
+    }
+
+    fun appendEntry(record: GeminiTranscriptRecord): Long {
+        val db = writableDatabase
+        val values = ContentValues().apply {
+            put(COL_SESSION_ID, record.sessionId)
+            put(COL_HOST_ID, record.hostId)
+            put(COL_HOST_LABEL, record.hostLabel)
+            put(COL_TIMESTAMP, record.timestamp)
+            put(COL_USER_MESSAGE, record.userMessage)
+            put(COL_GEMINI_REPLY, record.geminiReply)
+            put(COL_COMMAND_EXECUTED, record.commandExecuted)
+            put(COL_COMMAND_OUTPUT, record.commandOutput)
+            put(COL_SUCCESS, if (record.success) 1 else 0)
+        }
+        val id = db.insert(TABLE, null, values)
+        refreshSessionsFlow()
+        return id
+    }
+
+    fun getEntriesForSession(sessionId: String): List<GeminiTranscriptRecord> {
+        val rows = mutableListOf<GeminiTranscriptRecord>()
+        val cursor = readableDatabase.query(
+            TABLE,
+            null,
+            "$COL_SESSION_ID = ?",
+            arrayOf(sessionId),
+            null,
+            null,
+            "$COL_TIMESTAMP ASC, $COL_ID ASC"
+        )
+        cursor.use {
+            val idIdx = it.getColumnIndexOrThrow(COL_ID)
+            val sessionIdx = it.getColumnIndexOrThrow(COL_SESSION_ID)
+            val hostIdIdx = it.getColumnIndexOrThrow(COL_HOST_ID)
+            val hostLabelIdx = it.getColumnIndexOrThrow(COL_HOST_LABEL)
+            val tsIdx = it.getColumnIndexOrThrow(COL_TIMESTAMP)
+            val userIdx = it.getColumnIndexOrThrow(COL_USER_MESSAGE)
+            val replyIdx = it.getColumnIndexOrThrow(COL_GEMINI_REPLY)
+            val cmdIdx = it.getColumnIndexOrThrow(COL_COMMAND_EXECUTED)
+            val outIdx = it.getColumnIndexOrThrow(COL_COMMAND_OUTPUT)
+            val successIdx = it.getColumnIndexOrThrow(COL_SUCCESS)
+            while (it.moveToNext()) {
+                rows.add(
+                    GeminiTranscriptRecord(
+                        id = it.getLong(idIdx),
+                        sessionId = it.getString(sessionIdx),
+                        hostId = if (it.isNull(hostIdIdx)) null else it.getString(hostIdIdx),
+                        hostLabel = if (it.isNull(hostLabelIdx)) null else it.getString(hostLabelIdx),
+                        timestamp = it.getLong(tsIdx),
+                        userMessage = it.getString(userIdx),
+                        geminiReply = it.getString(replyIdx),
+                        commandExecuted = if (it.isNull(cmdIdx)) null else it.getString(cmdIdx),
+                        commandOutput = if (it.isNull(outIdx)) null else it.getString(outIdx),
+                        success = it.getInt(successIdx) != 0
+                    )
+                )
+            }
+        }
+        return rows
+    }
+
+    fun getAllSessions(): List<GeminiTranscriptSessionSummary> {
+        val sessions = mutableListOf<GeminiTranscriptSessionSummary>()
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT
+                $COL_SESSION_ID,
+                MAX($COL_HOST_LABEL) AS host_label,
+                COUNT(*) AS turn_count,
+                MIN($COL_TIMESTAMP) AS started_at,
+                MAX($COL_TIMESTAMP) AS last_activity_at
+            FROM $TABLE
+            GROUP BY $COL_SESSION_ID
+            ORDER BY last_activity_at DESC
+            """.trimIndent(),
+            null
+        )
+        cursor.use {
+            val sessionIdx = it.getColumnIndexOrThrow(COL_SESSION_ID)
+            val hostLabelIdx = it.getColumnIndexOrThrow("host_label")
+            val countIdx = it.getColumnIndexOrThrow("turn_count")
+            val startIdx = it.getColumnIndexOrThrow("started_at")
+            val lastIdx = it.getColumnIndexOrThrow("last_activity_at")
+            while (it.moveToNext()) {
+                val sessionId = it.getString(sessionIdx)
+                sessions.add(
+                    GeminiTranscriptSessionSummary(
+                        sessionId = sessionId,
+                        hostLabel = if (it.isNull(hostLabelIdx)) null else it.getString(hostLabelIdx),
+                        firstMessage = firstMessageFor(sessionId).orEmpty(),
+                        turnCount = it.getInt(countIdx),
+                        startedAt = it.getLong(startIdx),
+                        lastActivityAt = it.getLong(lastIdx)
+                    )
+                )
+            }
+        }
+        return sessions
+    }
+
+    private fun firstMessageFor(sessionId: String): String? {
+        val cursor = readableDatabase.query(
+            TABLE,
+            arrayOf(COL_USER_MESSAGE),
+            "$COL_SESSION_ID = ?",
+            arrayOf(sessionId),
+            null,
+            null,
+            "$COL_TIMESTAMP ASC, $COL_ID ASC",
+            "1"
+        )
+        cursor.use {
+            return if (it.moveToFirst()) it.getString(0) else null
+        }
+    }
+
+    fun deleteSession(sessionId: String): Int {
+        val rows = writableDatabase.delete(TABLE, "$COL_SESSION_ID = ?", arrayOf(sessionId))
+        refreshSessionsFlow()
+        return rows
+    }
+
+    fun clearAll(): Int {
+        val rows = writableDatabase.delete(TABLE, null, null)
+        refreshSessionsFlow()
+        return rows
+    }
+
+    private fun refreshSessionsFlow() {
+        _sessionsFlow.value = getAllSessions()
+    }
+
+    companion object {
+        private const val DATABASE_VERSION = 1
+        private const val DATABASE_NAME = "sushi_gemini_transcripts.db"
+        private const val TABLE = "transcripts"
+        private const val COL_ID = "id"
+        private const val COL_SESSION_ID = "session_id"
+        private const val COL_HOST_ID = "host_id"
+        private const val COL_HOST_LABEL = "host_label"
+        private const val COL_TIMESTAMP = "timestamp"
+        private const val COL_USER_MESSAGE = "user_message"
+        private const val COL_GEMINI_REPLY = "gemini_reply"
+        private const val COL_COMMAND_EXECUTED = "command_executed"
+        private const val COL_COMMAND_OUTPUT = "command_output"
+        private const val COL_SUCCESS = "success"
+
+        @Volatile
+        private var INSTANCE: GeminiTranscriptDatabaseHelper? = null
+
+        fun getInstance(context: Context): GeminiTranscriptDatabaseHelper {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: GeminiTranscriptDatabaseHelper(context.applicationContext)
+                    .also { INSTANCE = it }
+            }
+        }
+
+        @androidx.annotation.VisibleForTesting
+        fun resetInstance() {
+            synchronized(this) {
+                INSTANCE?.close()
+                INSTANCE = null
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/GeminiTranscriptRecord.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiTranscriptRecord.kt
@@ -1,0 +1,33 @@
+package net.hlan.sushi
+
+/**
+ * Persistent record of a single Gemini conversation turn, stored in SQLite.
+ *
+ * Distinct from [GeminiTranscriptEntry], which is the lightweight in-memory shape used
+ * by the active dialog. Records are written by [ConversationManager] on every turn so
+ * that history is browsable across sessions (USER_STORIES G-6).
+ */
+data class GeminiTranscriptRecord(
+    val id: Long = 0L,
+    val sessionId: String,
+    val hostId: String?,
+    val hostLabel: String?,
+    val timestamp: Long,
+    val userMessage: String,
+    val geminiReply: String,
+    val commandExecuted: String?,
+    val commandOutput: String?,
+    val success: Boolean
+)
+
+/**
+ * Summary row for the history list — one entry per Gemini session.
+ */
+data class GeminiTranscriptSessionSummary(
+    val sessionId: String,
+    val hostLabel: String?,
+    val firstMessage: String,
+    val turnCount: Int,
+    val startedAt: Long,
+    val lastActivityAt: Long
+)

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -965,12 +965,22 @@ class MainActivity : AppCompatActivity() {
         }
 
         val useNano = geminiSettings.getNanoPreferred() && isNanoAvailable()
+        val activeConfig = sshSettings.getConfigOrNull()
+        val hostLabel = when {
+            activeConfig?.kind == HostKind.LOCAL -> activeConfig.alias.ifBlank { "Local shell" }
+            activeConfig != null -> activeConfig.alias.ifBlank { "${activeConfig.username}@${activeConfig.host}" }
+            else -> null
+        }
         conversationManager = ConversationManager(
             context = this,
             backend = backend,
             geminiClient = geminiClient,
             geminiNanoClient = nanoClient,
-            useNano = useNano
+            useNano = useNano,
+            transcriptStore = GeminiTranscriptDatabaseHelper.getInstance(this),
+            sessionId = java.util.UUID.randomUUID().toString(),
+            hostId = activeConfig?.id,
+            hostLabel = hostLabel
         )
 
         val initResult = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary

Persistence half of USER_STORIES G-6 ("full transcript of my Gemini voice conversation"). Each conversation turn is now saved to a local SQLite database, keyed by session and host.

- New `GeminiTranscriptDatabaseHelper` — `SQLiteOpenHelper` with reactive `StateFlow<List<GeminiTranscriptSessionSummary>>`. Schema: `session_id`, `host_id`, `host_label`, `timestamp`, `user_message`, `gemini_reply`, `command_executed`, `command_output`, `success`
- New `GeminiTranscriptRecord` and `GeminiTranscriptSessionSummary` models (separate from the in-memory `GeminiTranscriptEntry` used by the dialog)
- `ConversationManager`: accepts optional `transcriptStore`, `sessionId`, `hostId`, `hostLabel`; persists on every `addToHistory` call
- `MainActivity`: wires singleton helper and resolves `hostId`/`hostLabel` from active `SshConnectionConfig` (handles `LOCAL` kind)

## What's not in this PR

The browseable history UI (`GeminiHistoryActivity`) follows in a separate PR (WS2b) — this PR is the storage layer only.

## UI / UX changes

- [x] No — purely logic/backend change

## Test plan

- [x] `GeminiTranscriptDatabaseHelperTest` (instrumented): append, ordering, session grouping, nullable fields, deletion, singleton
- [ ] Manual: connect to a host, open Gemini dialog, send 2–3 messages → verify rows in DB via `adb shell run-as net.hlan.sushi sqlite3 databases/sushi_gemini_transcripts.db "SELECT session_id, user_message FROM transcripts;"`

## Checklist

- [x] No user-visible strings added (storage layer only)
- [x] No hardcoded secrets
- [x] No new reflection-loaded classes

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s)_