### PR TITLE
feat(ux): Gemini conversation history browser (WS2b)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,10 @@
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:exported="false"
             android:label="@string/terminal_title" />
+        <activity
+            android:name=".GeminiHistoryActivity"
+            android:exported="false"
+            android:label="@string/gemini_history_title" />
     </application>
 
 </manifest>

--- a/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
@@ -3,6 +3,7 @@ package net.hlan.sushi
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.format.DateFormat
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -11,8 +12,12 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,9 +25,7 @@ import kotlinx.coroutines.withContext
 import net.hlan.sushi.databinding.ActivityGeminiHistoryBinding
 import net.hlan.sushi.databinding.ItemGeminiHistorySessionBinding
 import net.hlan.sushi.databinding.ItemGeminiTranscriptBinding
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 
 class GeminiHistoryActivity : AppCompatActivity() {
 
@@ -65,19 +68,22 @@ class GeminiHistoryActivity : AppCompatActivity() {
     private fun showSessionList() {
         supportActionBar?.title = getString(R.string.gemini_history_title)
 
-        lifecycleScope.launch(Dispatchers.IO) {
-            val sessions = db.getAllSessions()
-            withContext(Dispatchers.Main) {
-                if (sessions.isEmpty()) {
-                    binding.geminiHistoryEmptyText.visibility = View.VISIBLE
-                    binding.geminiHistorySessionsRecycler.visibility = View.GONE
-                } else {
-                    binding.geminiHistoryEmptyText.visibility = View.GONE
-                    binding.geminiHistorySessionsRecycler.visibility = View.VISIBLE
-                    binding.geminiHistorySessionsRecycler.layoutManager =
-                        LinearLayoutManager(this@GeminiHistoryActivity)
-                    binding.geminiHistorySessionsRecycler.adapter = SessionListAdapter(sessions) { session ->
-                        startActivity(createIntentForSession(this@GeminiHistoryActivity, session.sessionId))
+        val adapter = SessionListAdapter(this) { session ->
+            startActivity(createIntentForSession(this, session.sessionId))
+        }
+        binding.geminiHistorySessionsRecycler.layoutManager = LinearLayoutManager(this)
+        binding.geminiHistorySessionsRecycler.adapter = adapter
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                db.sessionsFlow.collect { sessions ->
+                    if (sessions.isEmpty()) {
+                        binding.geminiHistoryEmptyText.visibility = View.VISIBLE
+                        binding.geminiHistorySessionsRecycler.visibility = View.GONE
+                    } else {
+                        binding.geminiHistoryEmptyText.visibility = View.GONE
+                        binding.geminiHistorySessionsRecycler.visibility = View.VISIBLE
+                        adapter.submitList(sessions)
                     }
                 }
             }
@@ -124,16 +130,15 @@ class GeminiHistoryActivity : AppCompatActivity() {
             .show()
     }
 
-    // --- Session list adapter ---
+    // --- Session list adapter (reactive via sessionsFlow, uses ListAdapter + DiffUtil) ---
 
-    private inner class SessionListAdapter(
-        private val sessions: List<GeminiTranscriptSessionSummary>,
+    private class SessionListAdapter(
+        private val context: Context,
         private val onSessionClick: (GeminiTranscriptSessionSummary) -> Unit
-    ) : RecyclerView.Adapter<SessionListAdapter.SessionVH>() {
+    ) : ListAdapter<GeminiTranscriptSessionSummary, SessionListAdapter.SessionVH>(DIFF) {
 
-        private val dateFormat = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault())
-
-        override fun getItemCount() = sessions.size
+        private val dateFormat = DateFormat.getMediumDateFormat(context)
+        private val timeFormat = DateFormat.getTimeFormat(context)
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SessionVH {
             val b = ItemGeminiHistorySessionBinding.inflate(
@@ -143,7 +148,7 @@ class GeminiHistoryActivity : AppCompatActivity() {
         }
 
         override fun onBindViewHolder(holder: SessionVH, position: Int) {
-            holder.bind(sessions[position])
+            holder.bind(getItem(position))
         }
 
         inner class SessionVH(private val b: ItemGeminiHistorySessionBinding) :
@@ -151,11 +156,28 @@ class GeminiHistoryActivity : AppCompatActivity() {
 
             fun bind(session: GeminiTranscriptSessionSummary) {
                 b.sessionHostLabel.text = session.hostLabel
-                    ?: getString(R.string.gemini_history_unknown_host)
+                    ?: context.getString(R.string.gemini_history_unknown_host)
                 b.sessionFirstMessage.text = session.firstMessage
-                b.sessionTurnCount.text = getString(R.string.gemini_history_turns, session.turnCount)
-                b.sessionTimestamp.text = dateFormat.format(Date(session.startedAt))
+                b.sessionTurnCount.text = context.resources.getQuantityString(
+                    R.plurals.gemini_history_turns, session.turnCount, session.turnCount
+                )
+                val date = Date(session.startedAt)
+                b.sessionTimestamp.text = "${dateFormat.format(date)} ${timeFormat.format(date)}"
                 b.root.setOnClickListener { onSessionClick(session) }
+            }
+        }
+
+        companion object {
+            private val DIFF = object : DiffUtil.ItemCallback<GeminiTranscriptSessionSummary>() {
+                override fun areItemsTheSame(
+                    a: GeminiTranscriptSessionSummary,
+                    b: GeminiTranscriptSessionSummary
+                ) = a.sessionId == b.sessionId
+
+                override fun areContentsTheSame(
+                    a: GeminiTranscriptSessionSummary,
+                    b: GeminiTranscriptSessionSummary
+                ) = a == b
             }
         }
     }

--- a/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
@@ -12,9 +12,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
@@ -74,17 +72,15 @@ class GeminiHistoryActivity : AppCompatActivity() {
         binding.geminiHistorySessionsRecycler.layoutManager = LinearLayoutManager(this)
         binding.geminiHistorySessionsRecycler.adapter = adapter
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                db.sessionsFlow.collect { sessions ->
-                    if (sessions.isEmpty()) {
-                        binding.geminiHistoryEmptyText.visibility = View.VISIBLE
-                        binding.geminiHistorySessionsRecycler.visibility = View.GONE
-                    } else {
-                        binding.geminiHistoryEmptyText.visibility = View.GONE
-                        binding.geminiHistorySessionsRecycler.visibility = View.VISIBLE
-                        adapter.submitList(sessions)
-                    }
+        lifecycleScope.launchWhenStarted {
+            db.sessionsFlow.collect { sessions ->
+                if (sessions.isEmpty()) {
+                    binding.geminiHistoryEmptyText.visibility = View.VISIBLE
+                    binding.geminiHistorySessionsRecycler.visibility = View.GONE
+                } else {
+                    binding.geminiHistoryEmptyText.visibility = View.GONE
+                    binding.geminiHistorySessionsRecycler.visibility = View.VISIBLE
+                    adapter.submitList(sessions)
                 }
             }
         }

--- a/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/GeminiHistoryActivity.kt
@@ -1,0 +1,220 @@
+package net.hlan.sushi
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.hlan.sushi.databinding.ActivityGeminiHistoryBinding
+import net.hlan.sushi.databinding.ItemGeminiHistorySessionBinding
+import net.hlan.sushi.databinding.ItemGeminiTranscriptBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class GeminiHistoryActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityGeminiHistoryBinding
+    private val db by lazy { GeminiTranscriptDatabaseHelper.getInstance(this) }
+    private var currentSessionId: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGeminiHistoryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.geminiHistoryToolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID)
+        currentSessionId = sessionId
+        if (sessionId != null) {
+            showTurns(sessionId)
+        } else {
+            showSessionList()
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if (currentSessionId != null) {
+            menuInflater.inflate(R.menu.menu_gemini_history_session, menu)
+        }
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> { finish(); true }
+            R.id.action_delete_session -> { confirmDeleteSession(currentSessionId!!); true }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun showSessionList() {
+        supportActionBar?.title = getString(R.string.gemini_history_title)
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val sessions = db.getAllSessions()
+            withContext(Dispatchers.Main) {
+                if (sessions.isEmpty()) {
+                    binding.geminiHistoryEmptyText.visibility = View.VISIBLE
+                    binding.geminiHistorySessionsRecycler.visibility = View.GONE
+                } else {
+                    binding.geminiHistoryEmptyText.visibility = View.GONE
+                    binding.geminiHistorySessionsRecycler.visibility = View.VISIBLE
+                    binding.geminiHistorySessionsRecycler.layoutManager =
+                        LinearLayoutManager(this@GeminiHistoryActivity)
+                    binding.geminiHistorySessionsRecycler.adapter = SessionListAdapter(sessions) { session ->
+                        startActivity(createIntentForSession(this@GeminiHistoryActivity, session.sessionId))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showTurns(sessionId: String) {
+        supportActionBar?.title = getString(R.string.gemini_history_session_title)
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val turns = db.getEntriesForSession(sessionId)
+            withContext(Dispatchers.Main) {
+                if (turns.isEmpty()) {
+                    binding.geminiHistoryEmptyText.visibility = View.VISIBLE
+                    binding.geminiHistoryTurnsRecycler.visibility = View.GONE
+                } else {
+                    binding.geminiHistoryEmptyText.visibility = View.GONE
+                    binding.geminiHistoryTurnsRecycler.visibility = View.VISIBLE
+                    binding.geminiHistoryTurnsRecycler.layoutManager =
+                        LinearLayoutManager(this@GeminiHistoryActivity)
+                    binding.geminiHistoryTurnsRecycler.adapter = TurnListAdapter(turns)
+                }
+            }
+        }
+    }
+
+    private fun confirmDeleteSession(sessionId: String) {
+        AlertDialog.Builder(this)
+            .setMessage(R.string.gemini_history_delete_session)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                lifecycleScope.launch(Dispatchers.IO) {
+                    db.deleteSession(sessionId)
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                            this@GeminiHistoryActivity,
+                            R.string.gemini_history_deleted,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        finish()
+                    }
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    // --- Session list adapter ---
+
+    private inner class SessionListAdapter(
+        private val sessions: List<GeminiTranscriptSessionSummary>,
+        private val onSessionClick: (GeminiTranscriptSessionSummary) -> Unit
+    ) : RecyclerView.Adapter<SessionListAdapter.SessionVH>() {
+
+        private val dateFormat = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault())
+
+        override fun getItemCount() = sessions.size
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SessionVH {
+            val b = ItemGeminiHistorySessionBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+            return SessionVH(b)
+        }
+
+        override fun onBindViewHolder(holder: SessionVH, position: Int) {
+            holder.bind(sessions[position])
+        }
+
+        inner class SessionVH(private val b: ItemGeminiHistorySessionBinding) :
+            RecyclerView.ViewHolder(b.root) {
+
+            fun bind(session: GeminiTranscriptSessionSummary) {
+                b.sessionHostLabel.text = session.hostLabel
+                    ?: getString(R.string.gemini_history_unknown_host)
+                b.sessionFirstMessage.text = session.firstMessage
+                b.sessionTurnCount.text = getString(R.string.gemini_history_turns, session.turnCount)
+                b.sessionTimestamp.text = dateFormat.format(Date(session.startedAt))
+                b.root.setOnClickListener { onSessionClick(session) }
+            }
+        }
+    }
+
+    // --- Turn detail adapter ---
+
+    private class TurnListAdapter(
+        private val turns: List<GeminiTranscriptRecord>
+    ) : RecyclerView.Adapter<TurnListAdapter.TurnVH>() {
+
+        override fun getItemCount() = turns.size
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TurnVH {
+            val b = ItemGeminiTranscriptBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+            return TurnVH(b)
+        }
+
+        override fun onBindViewHolder(holder: TurnVH, position: Int) {
+            holder.bind(turns[position])
+        }
+
+        class TurnVH(private val b: ItemGeminiTranscriptBinding) :
+            RecyclerView.ViewHolder(b.root) {
+
+            fun bind(record: GeminiTranscriptRecord) {
+                b.transcriptPromptContent.text = record.userMessage
+                b.transcriptResponseContent.text = record.geminiReply
+
+                val cmd = record.commandExecuted
+                if (!cmd.isNullOrBlank()) {
+                    b.transcriptCommandSection.visibility = View.VISIBLE
+                    b.transcriptCommandContent.text = cmd
+
+                    val output = record.commandOutput
+                    if (!output.isNullOrBlank()) {
+                        b.transcriptOutputLabel.visibility = View.VISIBLE
+                        b.transcriptOutputContent.visibility = View.VISIBLE
+                        b.transcriptOutputContent.text = output
+                    } else {
+                        b.transcriptOutputLabel.visibility = View.GONE
+                        b.transcriptOutputContent.visibility = View.GONE
+                    }
+                } else {
+                    b.transcriptCommandSection.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_SESSION_ID = "extra_session_id"
+
+        fun createIntent(context: Context): Intent =
+            Intent(context, GeminiHistoryActivity::class.java)
+
+        fun createIntentForSession(context: Context, sessionId: String): Intent =
+            Intent(context, GeminiHistoryActivity::class.java)
+                .putExtra(EXTRA_SESSION_ID, sessionId)
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -394,6 +394,9 @@ class MainActivity : AppCompatActivity() {
         dialogBinding.geminiDialogSettingsButton.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
         }
+        dialogBinding.geminiDialogHistoryButton.setOnClickListener {
+            startActivity(GeminiHistoryActivity.createIntent(this))
+        }
         dialogBinding.geminiDialogCopyButton.setOnClickListener {
             copyGeminiCommand()
         }

--- a/app/src/main/res/layout/activity_gemini_history.xml
+++ b/app/src/main/res/layout/activity_gemini_history.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/geminiHistoryToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface" />
+
+    <TextView
+        android:id="@+id/geminiHistoryEmptyText"
+        style="@style/TextAppearance.Sushi.Body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:gravity="center"
+        android:text="@string/gemini_history_empty"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/geminiHistorySessionsRecycler"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:scrollbars="vertical"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/geminiHistoryTurnsRecycler"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:scrollbars="vertical"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_gemini_controls.xml
+++ b/app/src/main/res/layout/dialog_gemini_controls.xml
@@ -42,6 +42,16 @@
         app:icon="@drawable/ic_settings"
         app:iconGravity="textStart" />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/geminiDialogHistoryButton"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/action_gemini_history"
+        app:icon="@drawable/ic_list"
+        app:iconGravity="textStart" />
+
     <!-- Text Input Section -->
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_gemini_history_session.xml
+++ b/app/src/main/res/layout/item_gemini_history_session.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/sessionHostLabel"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/sessionTimestamp"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/sessionFirstMessage"
+        style="@style/TextAppearance.Sushi.Body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:ellipsize="end"
+        android:maxLines="2" />
+
+    <TextView
+        android:id="@+id/sessionTurnCount"
+        style="@style/TextAppearance.Sushi.Caption"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="12dp"
+        android:background="@color/sushi_card_stroke" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_gemini_transcript.xml
+++ b/app/src/main/res/layout/item_gemini_transcript.xml
@@ -60,6 +60,58 @@
         android:paddingBottom="10dp"
         android:textColor="@color/sushi_terminal_text" />
 
+    <LinearLayout
+        android:id="@+id/transcriptCommandSection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/transcriptCommandLabel"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/gemini_transcript_command_label"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/transcriptCommandContent"
+            style="@style/TextAppearance.Sushi.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:background="@color/sushi_terminal_panel_dark"
+            android:fontFamily="monospace"
+            android:padding="8dp"
+            android:textColor="@color/sushi_terminal_text" />
+
+        <TextView
+            android:id="@+id/transcriptOutputLabel"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/gemini_transcript_output_label"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/transcriptOutputContent"
+            style="@style/TextAppearance.Sushi.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:background="@color/sushi_terminal_panel_dark"
+            android:fontFamily="monospace"
+            android:maxLines="8"
+            android:padding="8dp"
+            android:textColor="@color/sushi_terminal_text"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"

--- a/app/src/main/res/menu/menu_gemini_history_session.xml
+++ b/app/src/main/res/menu/menu_gemini_history_session.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_delete_session"
+        android:icon="@drawable/ic_delete"
+        android:title="@string/gemini_history_delete_session"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,7 +363,6 @@
     <!-- Gemini History Activity -->
     <string name="gemini_history_title">Gemini history</string>
     <string name="gemini_history_empty">No conversations yet.</string>
-    <string name="gemini_history_turns">%1$d turn(s)</string>
     <string name="gemini_history_session_title">Conversation</string>
     <string name="gemini_history_delete_session">Delete session</string>
     <string name="gemini_history_deleted">Session deleted.</string>
@@ -394,4 +393,10 @@
     <string name="connect_error_action_edit_credentials">Edit credentials</string>
     <string name="connect_error_action_edit_jump_host">Edit jump host</string>
     <string name="connect_error_action_view_host_key">View host key</string>
+
+    <!-- Plurals -->
+    <plurals name="gemini_history_turns">
+        <item quantity="one">%1$d turn</item>
+        <item quantity="other">%1$d turns</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="action_gemini_voice">Talk to Gemini</string>
     <string name="action_open_gemini">Open Gemini</string>
     <string name="action_gemini_settings">Settings</string>
+    <string name="action_gemini_history">History</string>
     <string name="gemini_dialog_title">Gemini voice assistant</string>
     <string name="action_copy_command">Copy command</string>
     <string name="gemini_command_copied">Command copied.</string>
@@ -356,6 +357,17 @@
     <string name="gemini_transcript_label">Conversation history</string>
     <string name="gemini_transcript_you_label">You</string>
     <string name="gemini_transcript_gemini_label">Gemini</string>
+    <string name="gemini_transcript_command_label">Command run</string>
+    <string name="gemini_transcript_output_label">Output</string>
+
+    <!-- Gemini History Activity -->
+    <string name="gemini_history_title">Gemini history</string>
+    <string name="gemini_history_empty">No conversations yet.</string>
+    <string name="gemini_history_turns">%1$d turn(s)</string>
+    <string name="gemini_history_session_title">Conversation</string>
+    <string name="gemini_history_delete_session">Delete session</string>
+    <string name="gemini_history_deleted">Session deleted.</string>
+    <string name="gemini_history_unknown_host">Unknown host</string>
     
     <!-- Conversation UI -->
     <string name="conversation_input_hint">Ask the system...</string>


### PR DESCRIPTION
## Summary

- Adds `GeminiHistoryActivity` — two-level navigation: session list → turn detail
- Session list rows show host label, first message, turn count, and start timestamp
- Turn detail uses the existing `item_gemini_transcript` bubbles; extends them with collapsible `commandExecuted` / `commandOutput` blocks (hidden in the live dialog)
- History button added to the Gemini controls dialog (`ic_list` icon)
- Delete session available via options menu on the detail screen
- `AndroidManifest.xml` updated; 12 new strings

Completes USER_STORIES **G-6** together with WS2a (PR #98, already merged).

## Test plan

- [ ] Open Gemini dialog → tap "History" → session list appears (or empty state if no history yet)
- [ ] Run a few Gemini turns that execute commands → re-open History → session appears with correct turn count
- [ ] Tap session → turns show with user/Gemini bubbles; command + output blocks visible for turns that executed a command
- [ ] Tap delete (options menu) → confirmation dialog → session gone from list
- [ ] Back navigation returns to session list from detail view
- [ ] Empty state text shown when no sessions exist

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s)_