### PR TITLE
feat(ux): first-run setup checklist card (FLOW_IMPROVEMENTS #2)

### DIFF
--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -148,6 +148,7 @@ class MainActivity : AppCompatActivity() {
         updateSessionUi()
         refreshPlaysPageState()
         warmUpNanoIfAvailable()
+        updateSetupChecklist()
     }
 
     override fun onDestroy() {
@@ -868,6 +869,44 @@ class MainActivity : AppCompatActivity() {
         binding.configureHostButton.visibility = if (config == null) View.VISIBLE else View.GONE
 
         refreshPlaysPageState()
+    }
+
+    private fun updateSetupChecklist() {
+        val state = SetupChecklist.evaluate(sshSettings, geminiSettings, driveAuthManager)
+        val card = binding.setupChecklistCard
+        if (state.requiredComplete) {
+            card.root.visibility = View.GONE
+            return
+        }
+        card.root.visibility = View.VISIBLE
+
+        val doneMarker = getString(R.string.setup_checklist_done_marker)
+        val pendingMarker = getString(R.string.setup_checklist_pending_marker)
+        val doneColor = getColor(android.R.color.holo_green_dark)
+        val pendingColor = getColor(android.R.color.darker_gray)
+
+        fun applyRow(statusView: android.widget.TextView, done: Boolean) {
+            statusView.text = if (done) doneMarker else pendingMarker
+            statusView.setTextColor(if (done) doneColor else pendingColor)
+        }
+
+        applyRow(card.checklistSshHostStatus, state.hasSshHost)
+        applyRow(card.checklistSshKeyStatus, state.hasSshKey)
+        applyRow(card.checklistGeminiStatus, state.hasGeminiKey)
+        applyRow(card.checklistDriveStatus, state.hasDriveAuth)
+
+        card.checklistSshHostRow.setOnClickListener {
+            startActivity(Intent(this, HostsActivity::class.java))
+        }
+        card.checklistSshKeyRow.setOnClickListener {
+            startActivity(Intent(this, KeysActivity::class.java))
+        }
+        card.checklistGeminiRow.setOnClickListener {
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
+        card.checklistDriveRow.setOnClickListener {
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
     }
 
     private inner class MainToolsPagerAdapter(

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -129,15 +129,16 @@ class MainActivity : AppCompatActivity() {
         }
 
         setupToolsPager()
+        setupChecklistClickHandlers()
 
         updateGeminiState()
         ManagedPlays.ensure(this, sshSettings.getPublicKey())
         refreshSessionLog()
         updateSessionUi()
-        
+
         val appVersion = AppUtils.getAppVersionInfo(this)
         binding.footerText.text = getString(R.string.placeholder_footer, appVersion.name)
-        
+
         // Set up SSH connection listener for conversation
         setupConnectionListener()
     }
@@ -871,30 +872,8 @@ class MainActivity : AppCompatActivity() {
         refreshPlaysPageState()
     }
 
-    private fun updateSetupChecklist() {
-        val state = SetupChecklist.evaluate(sshSettings, geminiSettings, driveAuthManager)
+    private fun setupChecklistClickHandlers() {
         val card = binding.setupChecklistCard
-        if (state.requiredComplete) {
-            card.root.visibility = View.GONE
-            return
-        }
-        card.root.visibility = View.VISIBLE
-
-        val doneMarker = getString(R.string.setup_checklist_done_marker)
-        val pendingMarker = getString(R.string.setup_checklist_pending_marker)
-        val doneColor = getColor(android.R.color.holo_green_dark)
-        val pendingColor = getColor(android.R.color.darker_gray)
-
-        fun applyRow(statusView: android.widget.TextView, done: Boolean) {
-            statusView.text = if (done) doneMarker else pendingMarker
-            statusView.setTextColor(if (done) doneColor else pendingColor)
-        }
-
-        applyRow(card.checklistSshHostStatus, state.hasSshHost)
-        applyRow(card.checklistSshKeyStatus, state.hasSshKey)
-        applyRow(card.checklistGeminiStatus, state.hasGeminiKey)
-        applyRow(card.checklistDriveStatus, state.hasDriveAuth)
-
         card.checklistSshHostRow.setOnClickListener {
             startActivity(Intent(this, HostsActivity::class.java))
         }
@@ -907,6 +886,31 @@ class MainActivity : AppCompatActivity() {
         card.checklistDriveRow.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
         }
+    }
+
+    private fun updateSetupChecklist() {
+        val state = SetupChecklist.evaluate(sshSettings, geminiSettings, driveAuthManager)
+        val card = binding.setupChecklistCard
+        if (state.requiredComplete) {
+            card.root.visibility = View.GONE
+            return
+        }
+        card.root.visibility = View.VISIBLE
+
+        val doneMarker = getString(R.string.setup_checklist_done_marker)
+        val pendingMarker = getString(R.string.setup_checklist_pending_marker)
+        val doneColor = getColor(R.color.sushi_green)
+        val pendingColor = getColor(R.color.sushi_slate)
+
+        fun applyRow(statusView: android.widget.TextView, done: Boolean) {
+            statusView.text = if (done) doneMarker else pendingMarker
+            statusView.setTextColor(if (done) doneColor else pendingColor)
+        }
+
+        applyRow(card.checklistSshHostStatus, state.hasSshHost)
+        applyRow(card.checklistSshKeyStatus, state.hasSshKey)
+        applyRow(card.checklistGeminiStatus, state.hasGeminiKey)
+        applyRow(card.checklistDriveStatus, state.hasDriveAuth)
     }
 
     private inner class MainToolsPagerAdapter(

--- a/app/src/main/java/net/hlan/sushi/SetupChecklist.kt
+++ b/app/src/main/java/net/hlan/sushi/SetupChecklist.kt
@@ -1,0 +1,23 @@
+package net.hlan.sushi
+
+data class SetupChecklistState(
+    val hasSshHost: Boolean,
+    val hasSshKey: Boolean,
+    val hasGeminiKey: Boolean,
+    val hasDriveAuth: Boolean
+) {
+    val requiredComplete: Boolean get() = hasSshHost && hasSshKey
+}
+
+object SetupChecklist {
+    fun evaluate(
+        sshSettings: SshSettings,
+        geminiSettings: GeminiSettings,
+        driveAuthManager: DriveAuthManager
+    ): SetupChecklistState = SetupChecklistState(
+        hasSshHost = sshSettings.getHosts().any { it.kind == HostKind.SSH },
+        hasSshKey = sshSettings.getPublicKey() != null,
+        hasGeminiKey = geminiSettings.isEnabled() && geminiSettings.getApiKey().isNotBlank(),
+        hasDriveAuth = driveAuthManager.getSignedInAccount() != null
+    )
+}

--- a/app/src/main/java/net/hlan/sushi/SetupChecklist.kt
+++ b/app/src/main/java/net/hlan/sushi/SetupChecklist.kt
@@ -17,7 +17,8 @@ object SetupChecklist {
     ): SetupChecklistState = SetupChecklistState(
         hasSshHost = sshSettings.getHosts().any { it.kind == HostKind.SSH },
         hasSshKey = sshSettings.getPublicKey() != null,
-        hasGeminiKey = geminiSettings.isEnabled() && geminiSettings.getApiKey().isNotBlank(),
+        hasGeminiKey = geminiSettings.isEnabled() &&
+            (geminiSettings.getApiKey().isNotBlank() || driveAuthManager.getSignedInAccount() != null),
         hasDriveAuth = driveAuthManager.getSignedInAccount() != null
     )
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,6 +36,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/titleText" />
 
+        <include
+            android:id="@+id/setupChecklistCard"
+            layout="@layout/card_setup_checklist"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/statusText" />
+
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/mainToolsTabLayout"
             android:layout_width="0dp"
@@ -43,7 +54,7 @@
             android:layout_marginTop="14dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/statusText"
+            app:layout_constraintTop_toBottomOf="@id/setupChecklistCard"
             app:tabIndicatorColor="@color/sushi_green"
             app:tabIndicatorFullWidth="false"
             app:tabMode="fixed"

--- a/app/src/main/res/layout/card_setup_checklist.xml
+++ b/app/src/main/res/layout/card_setup_checklist.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardBackgroundColor="?attr/colorSurfaceVariant"
+    app:cardElevation="2dp"
+    app:strokeColor="@color/sushi_card_stroke"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            style="@style/TextAppearance.Sushi.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/setup_checklist_title"
+            android:textStyle="bold" />
+
+        <TextView
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/setup_checklist_subtitle" />
+
+        <!-- SSH host row (required) -->
+        <LinearLayout
+            android:id="@+id/checklistSshHostRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/checklistSshHostStatus"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="24dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/checklistSshHostLabel"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/setup_checklist_add_host" />
+
+        </LinearLayout>
+
+        <!-- SSH key row (required) -->
+        <LinearLayout
+            android:id="@+id/checklistSshKeyRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/checklistSshKeyStatus"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="24dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/checklistSshKeyLabel"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/setup_checklist_generate_key" />
+
+        </LinearLayout>
+
+        <!-- Gemini API key row (optional) -->
+        <LinearLayout
+            android:id="@+id/checklistGeminiRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/checklistGeminiStatus"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="24dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/checklistGeminiLabel"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/setup_checklist_gemini_key" />
+
+        </LinearLayout>
+
+        <!-- Drive auth row (optional) -->
+        <LinearLayout
+            android:id="@+id/checklistDriveRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp">
+
+            <TextView
+                android:id="@+id/checklistDriveStatus"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="24dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/checklistDriveLabel"
+                style="@style/TextAppearance.Sushi.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/setup_checklist_drive_auth" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,16 @@
 <resources>
     <string name="app_name_short" translatable="false">Sushi</string>
     <string name="app_name_long" translatable="false">Sushi - SSH Client</string>
+    <!-- Setup checklist -->
+    <string name="setup_checklist_title">Get started</string>
+    <string name="setup_checklist_subtitle">Complete the steps below to start using Sushi.</string>
+    <string name="setup_checklist_add_host">Add an SSH host</string>
+    <string name="setup_checklist_generate_key">Generate an SSH key</string>
+    <string name="setup_checklist_gemini_key">Set up Gemini AI (optional)</string>
+    <string name="setup_checklist_drive_auth">Connect Google Drive (optional)</string>
+    <string name="setup_checklist_done_marker">✓</string>
+    <string name="setup_checklist_pending_marker">○</string>
+
     <string name="placeholder_status">Add SSH details in Settings to start a session.</string>
     <string name="placeholder_status_active">Connecting...</string>
     <string name="session_title">Terminal session</string>

--- a/app/src/test/java/net/hlan/sushi/SetupChecklistTest.kt
+++ b/app/src/test/java/net/hlan/sushi/SetupChecklistTest.kt
@@ -1,0 +1,26 @@
+package net.hlan.sushi
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SetupChecklistTest {
+
+    private fun state(
+        hasSshHost: Boolean = false,
+        hasSshKey: Boolean = false,
+        hasGeminiKey: Boolean = false,
+        hasDriveAuth: Boolean = false
+    ) = SetupChecklistState(hasSshHost, hasSshKey, hasGeminiKey, hasDriveAuth)
+
+    @Test fun required_nothingConfigured() = assertFalse(state().requiredComplete)
+    @Test fun required_onlyHost() = assertFalse(state(hasSshHost = true).requiredComplete)
+    @Test fun required_onlyKey() = assertFalse(state(hasSshKey = true).requiredComplete)
+    @Test fun required_hostAndKey() = assertTrue(state(hasSshHost = true, hasSshKey = true).requiredComplete)
+    @Test fun required_optionalsDoNotUnblock() = assertFalse(
+        state(hasGeminiKey = true, hasDriveAuth = true).requiredComplete
+    )
+    @Test fun required_allConfigured() = assertTrue(
+        state(hasSshHost = true, hasSshKey = true, hasGeminiKey = true, hasDriveAuth = true).requiredComplete
+    )
+}


### PR DESCRIPTION
## Summary

- Persistent card at the top of `MainActivity` that guides new users through the minimum required configuration (SSH host + SSH key). Hides automatically once both required items are done.
- `SetupChecklist.evaluate()` reads `SshSettings`, `GeminiSettings`, `DriveAuthManager` — pure logic, no Android framework dependency
- Four tappable rows: SSH host and SSH key (required), Gemini API key and Drive auth (optional, labelled as such)
- Row clicks navigate directly: Hosts → `HostsActivity`, Keys → `KeysActivity`, Gemini/Drive → `SettingsActivity`
- 6 unit tests for `SetupChecklistState.requiredComplete` combinations

## Test plan

- [ ] Fresh install / cleared data → checklist card appears between status text and tools tabs
- [ ] Configure SSH host → host row gets ✓ marker
- [ ] Generate SSH key → key row gets ✓ marker; both required done → card disappears on next `onResume`
- [ ] Tap each row → navigates to the correct screen
- [ ] Return from settings after completing required items → card hidden
- [ ] Optional rows (Gemini, Drive) don't block card from hiding
- [ ] Run `./gradlew testDebugUnitTest --tests "net.hlan.sushi.SetupChecklistTest"` → all 6 pass

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s)_