### PR TITLE
docs: close out v0.6.0 — ROADMAP + USER_STORIES update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,15 +36,15 @@ Solidify the terminal layer first — the conversational features all sit on top
 
 ### Conversation depth
 
-| PR | Branch | Scope | Status |
-|----|--------|-------|--------|
-| — | ~~`feature/play-parameter-ux`~~ | Play parameter defaults, descriptions, examples; live preview in run dialog; required-vs-optional distinction | ✅ |
-| WS2a | ~~`feature/gemini-transcript-persistence`~~ | Gemini transcript persistence — SQLite-backed session history with command/output entries per turn | ✅ |
-| WS2b | ~~`feature/gemini-history-ui`~~ | Gemini history browser — session list + turn detail view, delete session, command/output display | ✅ |
-| C | ~~`feature/connection-error-classification`~~ | Connection error classification — typed `ConnectFailure` enum, actionable error banner, smart retry gating | ✅ |
-| D | ~~`feature/first-run-setup-checklist`~~ | First-run setup checklist — persistent card guides new users through SSH host + key + optional Gemini/Drive | ✅ |
-| 4 | `feature/raw-terminal-mode` | [Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md) — switch between AI conversation and direct shell | deferred → v0.7.0 |
-| 5 | `feature/output-streaming` | Command output streaming — token-by-token delivery for long-running commands (scope needs re-evaluation) | deferred → v0.7.0 |
+| Feature | Branch | Scope | Status |
+|---------|--------|-------|--------|
+| Play UX | ~~`feature/play-parameter-ux`~~ | Play parameter defaults, descriptions, examples; live preview in run dialog; required-vs-optional distinction | ✅ |
+| Transcript persistence | ~~`feature/gemini-transcript-persistence`~~ | Gemini transcript persistence — SQLite-backed session history with command/output entries per turn | ✅ |
+| History UI | ~~`feature/gemini-history-ui`~~ | Gemini history browser — session list + turn detail view, delete session, command/output display | ✅ |
+| Connection errors | ~~`feature/connection-error-classification`~~ | Connection error classification — typed `ConnectFailure` enum, actionable error banner, smart retry gating | ✅ |
+| [Setup checklist](docs/features/first-run-onboarding.md) | ~~`feature/first-run-setup-checklist`~~ | First-run setup checklist — persistent card guides new users through SSH host + key + optional Gemini/Drive | ✅ |
+| [Raw terminal mode](docs/features/raw-terminal-mode.md) | `feature/raw-terminal-mode` | Raw Terminal Mode toggle — switch between AI conversation and direct shell | deferred → v0.7.0 |
+| Output streaming | `feature/output-streaming` | Command output streaming — token-by-token delivery for long-running commands (scope needs re-evaluation) | deferred → v0.7.0 |
 
 ---
 
@@ -58,7 +58,7 @@ Also picks up the two deferred v0.6.0 terminal items.
 - **Custom log location** — read `log_dir` from `~/.config/sushi/config.conf` and honour it; the config key exists, enforcement does not
 - **Connection keep-alive in background** *(T-8)* — session should only disconnect on explicit action, not when the app backgrounds
 - **[Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md)** — switch between AI conversation and direct shell (deferred from v0.6.0)
-- **Command output streaming** — token-by-token delivery for long-running commands; scope to be re-evaluated (deferred from v0.6.0)
+- **Command output streaming** — token-by-token delivery for long-running commands (scope needs re-evaluation) (deferred from v0.6.0)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,21 +39,26 @@ Solidify the terminal layer first — the conversational features all sit on top
 | PR | Branch | Scope | Status |
 |----|--------|-------|--------|
 | — | ~~`feature/play-parameter-ux`~~ | Play parameter defaults, descriptions, examples; live preview in run dialog; required-vs-optional distinction | ✅ |
-| 6 | `feature/gemini-transcript` | Gemini transcript persistence — SQLite-backed session history with command/output entries, browsable history UI | 🔄 in progress |
-| 4 | `feature/raw-terminal-mode` | [Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md) — switch between AI conversation and direct shell | — |
-| 5 | `feature/output-streaming` | Command output streaming — token-by-token delivery for long-running commands | — |
-| 7 | `feature/first-run-onboarding` | [First-run onboarding](docs/features/first-run-onboarding.md) — guide user through `SUSHI.md` setup on first connect | — |
+| WS2a | ~~`feature/gemini-transcript-persistence`~~ | Gemini transcript persistence — SQLite-backed session history with command/output entries per turn | ✅ |
+| WS2b | ~~`feature/gemini-history-ui`~~ | Gemini history browser — session list + turn detail view, delete session, command/output display | ✅ |
+| C | ~~`feature/connection-error-classification`~~ | Connection error classification — typed `ConnectFailure` enum, actionable error banner, smart retry gating | ✅ |
+| D | ~~`feature/first-run-setup-checklist`~~ | First-run setup checklist — persistent card guides new users through SSH host + key + optional Gemini/Drive | ✅ |
+| 4 | `feature/raw-terminal-mode` | [Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md) — switch between AI conversation and direct shell | deferred → v0.7.0 |
+| 5 | `feature/output-streaming` | Command output streaming — token-by-token delivery for long-running commands (scope needs re-evaluation) | deferred → v0.7.0 |
 
 ---
 
-## v0.7.0 — Persona and file operations
+## v0.7.0 — Persona, file operations, and terminal depth
 
 Close the loop on persona editing and add the file operations that conversational users naturally ask for.
+Also picks up the two deferred v0.6.0 terminal items.
 
 - **[Remote SUSHI.md editor](docs/features/persona-editor.md)** — read and write `~/.config/sushi/SUSHI.md` from within the app; right now customizing the persona requires a separate SSH terminal
 - **[SFTP file operations](docs/features/file-operations.md)** — "download this log to my phone" is a natural conversational request; `SshClient` already handles upload via the Share target, download is the missing half *(B-17)*
 - **Custom log location** — read `log_dir` from `~/.config/sushi/config.conf` and honour it; the config key exists, enforcement does not
 - **Connection keep-alive in background** *(T-8)* — session should only disconnect on explicit action, not when the app backgrounds
+- **[Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md)** — switch between AI conversation and direct shell (deferred from v0.6.0)
+- **Command output streaming** — token-by-token delivery for long-running commands; scope to be re-evaluated (deferred from v0.6.0)
 
 ---
 

--- a/docs/process/USER_STORIES.md
+++ b/docs/process/USER_STORIES.md
@@ -70,7 +70,7 @@ All stories below break this epic into specific capabilities.
 | G-3 | As a user, I want to toggle between on-device and cloud Gemini models so that I can choose speed vs capability. | P1 | Done |
 | G-4 | As a user, I want to choose between Flash and Pro cloud models so that I can balance cost and quality. | P2 | Done |
 | G-5 | As a user, I want to copy a Gemini-suggested command so that I can paste and edit it before running. | P1 | Done |
-| G-6 | As a user, I want a full transcript of my Gemini voice conversation — what I said, what Gemini replied, and the commands executed — so that I can review, audit, or learn from the interaction. | P1 | Partial |
+| G-6 | As a user, I want a full transcript of my Gemini voice conversation — what I said, what Gemini replied, and the commands executed — so that I can review, audit, or learn from the interaction. | P1 | Done |
 
 ## Google Drive Integration
 


### PR DESCRIPTION
## Summary

- `ROADMAP.md`: marks all four v0.6.0 conversation-depth PRs as ✅ (WS2a, WS2b, connection-error-classification, first-run-setup-checklist); moves deferred PRs 4 (raw-terminal-mode) and 5 (output-streaming) to v0.7.0 with explanatory notes; updates v0.7.0 title
- `docs/process/USER_STORIES.md`: G-6 status Partial → Done

No code changes — docs only.

## Test plan

- [ ] ROADMAP.md v0.6.0 table shows all four completed PRs as ✅
- [ ] v0.7.0 section lists raw-terminal-mode and output-streaming with "deferred from v0.6.0" notes
- [ ] USER_STORIES.md G-6 shows "Done"

https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPmUvXkV54WkyTByCs1R4s)_