### PR TITLE
fix(release): hotfix startup crash and prep v0.6.1 release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,14 +209,12 @@ jobs:
             -PversionCode="$ANDROID_VERSION_CODE"
 
       - name: Upload App Bundle to release
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload-url }}
-          asset_path: app/build/outputs/bundle/release/app-release.aab
-          asset_name: sushi-ssh-client-android.aab
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.create-release.outputs.release-tag }}" \
+            "app/build/outputs/bundle/release/app-release.aab#sushi-ssh-client-android.aab" \
+            --clobber
 
       - name: Upload to Google Play
         if: ${{ needs.create-release.outputs.deploy-android == 'true' && env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON != '' }}
@@ -226,5 +224,5 @@ jobs:
           packageName: net.hlan.sushi
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           mappingFile: app/build/outputs/mapping/release/mapping.txt
-          track: ${{ needs.create-release.outputs.play-track }}
+          tracks: ${{ needs.create-release.outputs.play-track }}
           status: completed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Sushi is an Android SSH client. Package `net.hlan.sushi`, single Gradle module `:app`, Kotlin DSL, JDK 17, min SDK 24, target SDK 36. No Compose, no ViewModel/MVVM — activity-based with view binding.
+Sushi is an Android SSH client. Package `net.hlan.sushi`, single Gradle module `:app`, Kotlin DSL, JDK 17, min SDK 26, target SDK 36. No Compose, no ViewModel/MVVM — activity-based with view binding.
 
 `CLAUDE.md` covers the same ground in more detail; keep the two reconciled when changing one.
 
@@ -17,6 +17,12 @@ Sushi is an Android SSH client. Package `net.hlan.sushi`, single Gradle module `
 ```
 
 Reports: `app/build/reports/`. Version overrides: `-PversionCode=...`, `-PversionName=...`.
+
+## Machine setup (non-obvious)
+
+- `local.properties` is gitignored; each machine must set `sdk.dir=/absolute/path/to/sdk`.
+- Required SDK packages: `platform-tools`, `platforms;android-36`, `build-tools;36.0.0`, `ndk;27.0.12077973`, `cmake;3.22.1`.
+- If native builds fail, validate NDK clang directly at `.../ndk/27.0.12077973/toolchains/llvm/prebuilt/.../bin/clang --version` and install missing host compatibility libs.
 
 ## Build types (non-obvious)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Sushi is an Android SSH client (package `net.hlan.sushi`, min SDK 24, target SDK 36). Single Gradle module `:app`, Kotlin DSL, JDK 17 required.
+Sushi is an Android SSH client (package `net.hlan.sushi`, min SDK 26, target SDK 36). Single Gradle module `:app`, Kotlin DSL, JDK 17 required.
 
 ## Build commands
 
@@ -20,6 +20,14 @@ Sushi is an Android SSH client (package `net.hlan.sushi`, min SDK 24, target SDK
 ```
 
 Lint reports go to `app/build/reports/`.
+
+## Machine-specific setup
+
+- `local.properties` is gitignored; set `sdk.dir=/absolute/path/to/sdk` on each machine.
+- Required SDK packages: `platform-tools`, `platforms;android-36`, `build-tools;36.0.0`, `ndk;27.0.12077973`, `cmake;3.22.1`.
+- If native builds fail, validate NDK toolchain directly:
+  `.../ndk/27.0.12077973/toolchains/llvm/prebuilt/.../bin/clang --version`
+  and install missing host compatibility libraries.
 
 ### Local dev scripts
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ Prerequisites:
 - Android Studio (Hedgehog or newer recommended)
 - JDK 17
 
+Android SDK/NDK setup (machine-specific):
+- `local.properties` is gitignored and must be set per machine:
+  ```properties
+  sdk.dir=/absolute/path/to/your/Android/sdk
+  ```
+- This project requires these SDK components:
+  ```bash
+  sdkmanager \
+    "platform-tools" \
+    "platforms;android-36" \
+    "build-tools;36.0.0" \
+    "ndk;27.0.12077973" \
+    "cmake;3.22.1"
+  ```
+- Quick verification:
+  ```bash
+  ./gradlew assembleDebug
+  ./gradlew assembleMinifiedDebug
+  ```
+
+If native build setup fails on Linux hosts:
+- The NDK toolchain binaries under `ndk/27.0.12077973/toolchains/llvm/prebuilt/...` must run on your host.
+- Validate directly:
+  ```bash
+  "$ANDROID_SDK_ROOT/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/bin/clang" --version
+  ```
+- If that command fails due to missing shared libraries, install the required compatibility libs for your distro/architecture, then retry.
+
 Optional integrations:
 - Gemini voice mode: add your API key in app settings.
 - Google Drive logs: create an OAuth client for the package `net.hlan.sushi` and enable the Drive API.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -52,6 +52,15 @@
 # LocalShellBackend is referenced by JNI symbol names (Java_net_hlan_sushi_LocalShellBackend_native*).
 -keep class net.hlan.sushi.LocalShellBackend { *; }
 
+# HostKind is serialized/deserialized by Moshi from persisted JSON ("SSH"/"LOCAL").
+# Keep enum constant names stable in minified builds.
+-keepclassmembers enum net.hlan.sushi.HostKind {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+    public static final net.hlan.sushi.HostKind SSH;
+    public static final net.hlan.sushi.HostKind LOCAL;
+}
+
 # ListAdapter.getCurrentList() is called from instrumented tests against the minified build.
 -keepclassmembers class * extends androidx.recyclerview.widget.ListAdapter {
     public java.util.List getCurrentList();


### PR DESCRIPTION
## Summary
- Fix release/minified startup crash by preserving `HostKind` enum constant names used by Moshi when reading persisted host JSON (`SSH`/`LOCAL`).
- Update release workflow to remove deprecated release-asset action usage and migrate Play upload input from `track` to `tracks`.
- Add machine-specific Android SDK/NDK setup guidance (`local.properties`, required SDK packages, and native toolchain validation) and align docs metadata.

## Validation
- Reproduced v0.6.0 startup crash on device from release AAB (`NoSuchFieldException: SSH`).
- Built and installed patched `minifiedDebug` build; cold-start no longer crashes.
- Built release AAB (`bundleRelease`) and installed release-equivalent APKs via bundletool (`versionCode=60002`, `versionName=0.6.1-rc1`); cold-start no longer crashes and process stays alive.