### PR TITLE
ci(device-tests): add helper to install adb as a systemd service

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -70,6 +70,12 @@ jobs:
           # When set, the step connects via TCP instead of relying on the host server.
           DEVICE_ADDRESS: ${{ secrets.ANDROID_DEVICE_ADDRESS }}
         run: |
+          if ! command -v adb >/dev/null 2>&1; then
+            echo "::error::'adb' is not installed in the runner container. Add 'android-tools-adb' to the runner image."
+            exit 1
+          fi
+          adb --version
+
           export ANDROID_ADB_SERVER_ADDRESS="$ADB_HOST"
           export ANDROID_ADB_SERVER_PORT="$ADB_PORT"
 
@@ -82,15 +88,46 @@ jobs:
 
           DEVICE_COUNT=$(adb devices | grep -v "^List" | grep "device$" | wc -l)
           if [ "$DEVICE_COUNT" -eq 0 ]; then
-            echo "::error::No Android device found. Check USB/Wi-Fi connection, ADB authorisation, and that the host ADB server is running (adb start-server on ergo)."
+            echo "::error::No Android device found. Check USB/Wi-Fi connection, ADB authorisation, and that the host ADB server is running (sudo systemctl status adb-server on ergo)."
             exit 1
           fi
           echo "Found $DEVICE_COUNT device(s) — continuing."
+
+          # Log device identity so test failures can be correlated with the unit.
+          echo "Model:    $(adb shell getprop ro.product.model | tr -d '\r')"
+          echo "Brand:    $(adb shell getprop ro.product.brand | tr -d '\r')"
+          echo "Android:  $(adb shell getprop ro.build.version.release | tr -d '\r') (API $(adb shell getprop ro.build.version.sdk | tr -d '\r'))"
 
           # Persist ADB env for subsequent steps.
           echo "ANDROID_ADB_SERVER_ADDRESS=$ADB_HOST" >> "$GITHUB_ENV"
           echo "ANDROID_ADB_SERVER_PORT=$ADB_PORT"    >> "$GITHUB_ENV"
           [ -n "$DEVICE_ADDRESS" ] && echo "ANDROID_SERIAL=$DEVICE_ADDRESS" >> "$GITHUB_ENV" || true
+
+      - name: Prepare device for instrumented tests
+        run: |
+          # Wake the device and dismiss the keyguard. This requires the device's
+          # secure lockscreen to be set to None or Swipe — `wm dismiss-keyguard`
+          # cannot bypass PIN/pattern/password.
+          adb shell input keyevent KEYCODE_WAKEUP
+          adb shell wm dismiss-keyguard
+
+          # Keep the screen on while plugged in (USB | AC | wireless = 7) so the
+          # device doesn't sleep mid-test and trigger NoActivityResumedException.
+          adb shell settings put global stay_on_while_plugged_in 7
+
+          # Zero animation scales — Espresso waits for animations to settle, and
+          # non-zero scales are a common source of flakes on Android 15+.
+          adb shell settings put global window_animation_scale 0
+          adb shell settings put global transition_animation_scale 0
+          adb shell settings put global animator_duration_scale 0
+
+          # Verify the device is unlocked and an activity can resume. If the
+          # lockscreen is secure, mWindowFocusCleared/mDreaming will report the
+          # keyguard is still up and tests will fail later anyway — fail fast.
+          if adb shell dumpsys window 2>/dev/null | grep -q "mDreamingLockscreen=true"; then
+            echo "::error::Secure lockscreen is active and could not be dismissed. Set the device lockscreen to None or Swipe."
+            exit 1
+          fi
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Lint reports go to `app/build/reports/`.
 ./scripts/setup-local-ssh-test.sh          # wizard to store SSH test credentials
 ./scripts/run-local-ssh-test.sh            # runs LocalSshIntegrationTest
 ./scripts/install-git-hooks.sh             # installs pre-push hook (runs unit tests)
+sudo ./scripts/install-adb-systemd-service.sh  # Device Tests runner host: adb as a systemd service
 ```
 
 Skip the pre-push hook with `SKIP_PRE_PUSH_TESTS=1 git push`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,9 @@ dependencies {
     // which conflicts with the androidTest dependencies (espresso/junit/concurrent-futures-ktx).
     implementation("androidx.concurrent:concurrent-futures:1.3.0")
     androidTestImplementation("androidx.concurrent:concurrent-futures:1.3.0")
-    androidTestImplementation("com.google.guava:guava:33.6.0-jre")
+    // Pin Guava to the -android flavor on both classpaths. AGP consistent resolution
+    // would otherwise pick the -jre flavor for androidTest and break minifiedDebugAndroidTestRuntimeClasspath.
+    implementation("com.google.guava:guava:33.6.0-android")
+    androidTestImplementation("com.google.guava:guava:33.6.0-android")
 
 }

--- a/docs/process/CI_DEVICE_TESTING.md
+++ b/docs/process/CI_DEVICE_TESTING.md
@@ -22,7 +22,7 @@ required check**. It is triggered manually or by adding the label
 |-------|--------|
 | RPi5 self-hosted runner | Running (Docker container) |
 | Nokia 4.2G USB connection | Connected to host `ergo` |
-| ADB on host | Needs to be started manually (`adb start-server`) |
+| ADB on host | Managed by `adb-server.service` (see install step below) |
 | Workflow | Committed, not yet exercised end-to-end |
 
 ---
@@ -52,39 +52,34 @@ adb -a -P 5037 start-server
 
 ---
 
-## Pending: make ADB a systemd service
+## Make ADB a systemd service
 
 Running `adb start-server` manually means the daemon is lost on reboot or if
-the process crashes. The daemon should be managed by systemd so it starts
-automatically and reconnects to the phone.
+the process crashes. Use the helper script to install a systemd unit that
+starts the daemon on boot and binds it to the Docker bridge so the runner
+container can reach it.
 
-### Proposed unit file `/etc/systemd/system/adb-server.service`
+### Install
 
-```ini
-[Unit]
-Description=Android Debug Bridge server
-After=network.target
-
-[Service]
-Type=forking
-User=larry
-# Bind to the Docker bridge so the runner container can connect.
-# Change the IP if your bridge address differs (ip -4 addr show docker0).
-Environment="ADB_SERVER_SOCKET=tcp:172.17.0.1:5037"
-ExecStart=/usr/bin/adb -a -P 5037 start-server
-ExecStop=/usr/bin/adb kill-server
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-```
-
-### Enable and verify
+From a checkout of this repo on the runner host:
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now adb-server
+sudo ./scripts/install-adb-systemd-service.sh
+```
+
+The script:
+- requires `adb` on `PATH` (`sudo apt install -y android-tools-adb`);
+- auto-detects the `docker0` bridge IP and runs adb as `$SUDO_USER`;
+- writes `/etc/systemd/system/adb-server.service`, enables it, and starts it;
+- prints `adb devices` against the bound socket to verify reachability.
+
+Override defaults with `--user <name>`, `--port <port>`, `--bridge-ip <ip>`, or
+`--all-interfaces` (binds `0.0.0.0` — only safe on trusted networks).
+Remove the service with `sudo ./scripts/install-adb-systemd-service.sh --uninstall`.
+
+### Verify
+
+```bash
 sudo systemctl status adb-server
 
 # Confirm the phone is reachable from the container

--- a/docs/process/CI_DEVICE_TESTING.md
+++ b/docs/process/CI_DEVICE_TESTING.md
@@ -111,6 +111,24 @@ The workflow falls back to `172.17.0.1:5037` if the variables are absent.
 
 ---
 
+## Phone configuration
+
+The QA phone must be set up so the workflow can drive it without manual help:
+
+- **Developer Options → USB debugging** enabled, host's ADB key authorised
+  ("Always allow from this computer").
+- **Secure lockscreen disabled** — set the lockscreen type to **None** or
+  **Swipe** in Settings → Security. The workflow runs `adb shell wm
+  dismiss-keyguard` to wake the device for Espresso, and that command cannot
+  bypass a PIN, pattern, or password. With a secure lockscreen enabled the
+  tests will fail with `NoActivityResumedException` because activities can
+  never gain window focus.
+- **Stay-awake while plugged in**, **animation scales** — set automatically by
+  the workflow's "Prepare device for instrumented tests" step on every run, so
+  no manual configuration needed.
+
+---
+
 ## Wi-Fi ADB (alternative, no USB passthrough needed)
 
 If USB passthrough becomes unreliable, the phone can be reached over Wi-Fi:

--- a/scripts/install-adb-systemd-service.sh
+++ b/scripts/install-adb-systemd-service.sh
@@ -10,12 +10,13 @@
 # Usage:
 #   sudo ./scripts/install-adb-systemd-service.sh [options]
 #
+# The daemon binds on 0.0.0.0:<port> (the Debian-packaged adb cannot bind to a
+# specific IP). Only safe on a trusted home/office network — do not run on a
+# host exposed to the public internet.
+#
 # Options:
 #   --user <name>        Run adb as this user (default: $SUDO_USER, else $USER)
 #   --port <port>        ADB daemon port (default: 5037)
-#   --bridge-ip <ip>     Bind ADB to this IP only (default: auto-detect docker0)
-#   --all-interfaces     Bind ADB to 0.0.0.0 instead of the bridge IP. Less safe
-#                        — only use on a trusted network.
 #   --uninstall          Stop, disable, and remove the service.
 #   -h, --help           Show this help.
 #
@@ -26,7 +27,7 @@ UNIT_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
 DEFAULT_PORT="5037"
 
 usage() {
-  sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '3,22p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 err() {
@@ -60,16 +61,12 @@ detect_bridge_ip() {
 
 ADB_USER=""
 PORT="$DEFAULT_PORT"
-BRIDGE_IP=""
-ALL_INTERFACES=0
 UNINSTALL=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --user)            ADB_USER="$2"; shift 2 ;;
     --port)            PORT="$2"; shift 2 ;;
-    --bridge-ip)       BRIDGE_IP="$2"; shift 2 ;;
-    --all-interfaces)  ALL_INTERFACES=1; shift ;;
     --uninstall)       UNINSTALL=1; shift ;;
     -h|--help)         usage; exit 0 ;;
     *)                 err "unknown option: $1" ;;
@@ -102,19 +99,12 @@ if ! id "$ADB_USER" >/dev/null 2>&1; then
   err "user '$ADB_USER' does not exist"
 fi
 
-if [ "$ALL_INTERFACES" -eq 1 ]; then
-  EXEC_START="${ADB_BIN} -a -P ${PORT} nodaemon server"
-  BIND_DESC="0.0.0.0:${PORT}"
-else
-  if [ -z "$BRIDGE_IP" ]; then
-    BRIDGE_IP="$(detect_bridge_ip || true)"
-  fi
-  if [ -z "$BRIDGE_IP" ]; then
-    err "could not auto-detect docker0 bridge IP. Pass --bridge-ip <ip> or --all-interfaces."
-  fi
-  EXEC_START="${ADB_BIN} -L tcp:${BRIDGE_IP}:${PORT} nodaemon server"
-  BIND_DESC="${BRIDGE_IP}:${PORT}"
-fi
+EXEC_START="${ADB_BIN} -a -P ${PORT} nodaemon server"
+BIND_DESC="0.0.0.0:${PORT}"
+
+# Used only as the address for the post-install reachability check.
+BRIDGE_IP="$(detect_bridge_ip || true)"
+CHECK_HOST="${BRIDGE_IP:-127.0.0.1}"
 
 ADB_HOME="$(getent passwd "$ADB_USER" | cut -d: -f6)"
 if [ -z "$ADB_HOME" ]; then
@@ -132,6 +122,8 @@ Wants=network-online.target
 Type=simple
 User=${ADB_USER}
 Environment=HOME=${ADB_HOME}
+# Kill any stray user-started daemon so the bind on :${PORT} doesn't conflict.
+ExecStartPre=-${ADB_BIN} kill-server
 ExecStart=${EXEC_START}
 Restart=on-failure
 RestartSec=5
@@ -144,13 +136,13 @@ chmod 0644 "$UNIT_PATH"
 
 systemctl daemon-reload
 systemctl enable "${SERVICE_NAME}.service"
-systemctl restart "${SERVICE_NAME}.service"
 
-if [ "$ALL_INTERFACES" -eq 1 ]; then
-  CHECK_HOST="127.0.0.1"
-else
-  CHECK_HOST="$BRIDGE_IP"
-fi
+# Make sure no other adb daemon (user-started or previous unit) is holding
+# port ${PORT} on any interface before we bring the unit up.
+pkill -u "$ADB_USER" -x adb 2>/dev/null || true
+sleep 1
+
+systemctl restart "${SERVICE_NAME}.service"
 
 echo
 echo "Verifying ADB daemon is reachable on ${BIND_DESC}..."

--- a/scripts/install-adb-systemd-service.sh
+++ b/scripts/install-adb-systemd-service.sh
@@ -103,7 +103,8 @@ if ! id "$ADB_USER" >/dev/null 2>&1; then
 fi
 
 if [ "$ALL_INTERFACES" -eq 1 ]; then
-  SOCKET_DIRECTIVE="# Bound on all interfaces (--all-interfaces)."
+  EXEC_START="${ADB_BIN} -a -P ${PORT} nodaemon server"
+  BIND_DESC="0.0.0.0:${PORT}"
 else
   if [ -z "$BRIDGE_IP" ]; then
     BRIDGE_IP="$(detect_bridge_ip || true)"
@@ -111,9 +112,14 @@ else
   if [ -z "$BRIDGE_IP" ]; then
     err "could not auto-detect docker0 bridge IP. Pass --bridge-ip <ip> or --all-interfaces."
   fi
-  SOCKET_DIRECTIVE="Environment=\"ADB_SERVER_SOCKET=tcp:${BRIDGE_IP}:${PORT}\""
+  EXEC_START="${ADB_BIN} -L tcp:${BRIDGE_IP}:${PORT} nodaemon server"
+  BIND_DESC="${BRIDGE_IP}:${PORT}"
 fi
-EXEC_START="${ADB_BIN} -a -P ${PORT} start-server"
+
+ADB_HOME="$(getent passwd "$ADB_USER" | cut -d: -f6)"
+if [ -z "$ADB_HOME" ]; then
+  err "could not resolve home directory for user '$ADB_USER'"
+fi
 
 echo "Writing $UNIT_PATH"
 cat > "$UNIT_PATH" <<UNIT
@@ -123,11 +129,10 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 User=${ADB_USER}
-${SOCKET_DIRECTIVE}
+Environment=HOME=${ADB_HOME}
 ExecStart=${EXEC_START}
-ExecStop=${ADB_BIN} kill-server
 Restart=on-failure
 RestartSec=5
 
@@ -141,26 +146,34 @@ systemctl daemon-reload
 systemctl enable "${SERVICE_NAME}.service"
 systemctl restart "${SERVICE_NAME}.service"
 
-# Give the daemon a moment to bind.
-sleep 1
-
-systemctl --no-pager --full status "${SERVICE_NAME}.service" || true
-
-echo
-echo "Verifying ADB daemon is reachable..."
 if [ "$ALL_INTERFACES" -eq 1 ]; then
   CHECK_HOST="127.0.0.1"
 else
   CHECK_HOST="$BRIDGE_IP"
 fi
 
-if sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices >/dev/null 2>&1; then
-  echo "  OK — adb -H $CHECK_HOST -P $PORT reachable."
-  sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices
-else
-  echo "  WARNING — could not reach adb daemon at $CHECK_HOST:$PORT yet." >&2
-  echo "  Check 'journalctl -u ${SERVICE_NAME}.service' for errors." >&2
+echo
+echo "Verifying ADB daemon is reachable on ${BIND_DESC}..."
+ATTEMPTS=0
+while [ "$ATTEMPTS" -lt 10 ]; do
+  if sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices >/dev/null 2>&1; then
+    echo "  OK — adb -H $CHECK_HOST -P $PORT reachable."
+    sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices
+    break
+  fi
+  ATTEMPTS=$((ATTEMPTS + 1))
+  sleep 1
+done
+
+if [ "$ATTEMPTS" -ge 10 ]; then
+  echo "  WARNING — could not reach adb daemon at $CHECK_HOST:$PORT after 10s." >&2
+  echo "  Check 'journalctl -u ${SERVICE_NAME}.service -n 50' for errors." >&2
+  systemctl --no-pager --full status "${SERVICE_NAME}.service" || true
+  exit 1
 fi
+
+echo
+systemctl --no-pager status "${SERVICE_NAME}.service" || true
 
 echo
 echo "Done. The daemon will start automatically on reboot."

--- a/scripts/install-adb-systemd-service.sh
+++ b/scripts/install-adb-systemd-service.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Install adb as a systemd service on the Device Tests runner host.
+#
+# Run this once on the host that has the Android device attached via USB
+# (e.g. the RPi5 named "ergo"). It creates and enables a systemd unit so the
+# ADB daemon starts on boot and is reachable from the GitHub Actions Docker
+# runner container via the Docker bridge.
+#
+# Usage:
+#   sudo ./scripts/install-adb-systemd-service.sh [options]
+#
+# Options:
+#   --user <name>        Run adb as this user (default: $SUDO_USER, else $USER)
+#   --port <port>        ADB daemon port (default: 5037)
+#   --bridge-ip <ip>     Bind ADB to this IP only (default: auto-detect docker0)
+#   --all-interfaces     Bind ADB to 0.0.0.0 instead of the bridge IP. Less safe
+#                        — only use on a trusted network.
+#   --uninstall          Stop, disable, and remove the service.
+#   -h, --help           Show this help.
+#
+set -euo pipefail
+
+SERVICE_NAME="adb-server"
+UNIT_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
+DEFAULT_PORT="5037"
+
+usage() {
+  sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    err "must be run as root (use sudo)"
+  fi
+}
+
+detect_user() {
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    echo "$SUDO_USER"
+  else
+    echo "${USER:-root}"
+  fi
+}
+
+detect_bridge_ip() {
+  if ! command -v ip >/dev/null 2>&1; then
+    return 1
+  fi
+  ip -4 -o addr show docker0 2>/dev/null \
+    | awk '{print $4}' \
+    | cut -d/ -f1 \
+    | head -n 1
+}
+
+ADB_USER=""
+PORT="$DEFAULT_PORT"
+BRIDGE_IP=""
+ALL_INTERFACES=0
+UNINSTALL=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user)            ADB_USER="$2"; shift 2 ;;
+    --port)            PORT="$2"; shift 2 ;;
+    --bridge-ip)       BRIDGE_IP="$2"; shift 2 ;;
+    --all-interfaces)  ALL_INTERFACES=1; shift ;;
+    --uninstall)       UNINSTALL=1; shift ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 err "unknown option: $1" ;;
+  esac
+done
+
+require_root
+
+if [ "$UNINSTALL" -eq 1 ]; then
+  if systemctl list-unit-files | grep -q "^${SERVICE_NAME}.service"; then
+    systemctl disable --now "${SERVICE_NAME}.service" || true
+  fi
+  rm -f "$UNIT_PATH"
+  systemctl daemon-reload
+  echo "Removed ${SERVICE_NAME}.service"
+  exit 0
+fi
+
+if ! command -v adb >/dev/null 2>&1; then
+  err "adb not found on PATH. Install with: sudo apt install -y android-tools-adb"
+fi
+
+ADB_BIN="$(command -v adb)"
+
+if [ -z "$ADB_USER" ]; then
+  ADB_USER="$(detect_user)"
+fi
+
+if ! id "$ADB_USER" >/dev/null 2>&1; then
+  err "user '$ADB_USER' does not exist"
+fi
+
+if [ "$ALL_INTERFACES" -eq 1 ]; then
+  SOCKET_DIRECTIVE="# Bound on all interfaces (--all-interfaces)."
+else
+  if [ -z "$BRIDGE_IP" ]; then
+    BRIDGE_IP="$(detect_bridge_ip || true)"
+  fi
+  if [ -z "$BRIDGE_IP" ]; then
+    err "could not auto-detect docker0 bridge IP. Pass --bridge-ip <ip> or --all-interfaces."
+  fi
+  SOCKET_DIRECTIVE="Environment=\"ADB_SERVER_SOCKET=tcp:${BRIDGE_IP}:${PORT}\""
+fi
+EXEC_START="${ADB_BIN} -a -P ${PORT} start-server"
+
+echo "Writing $UNIT_PATH"
+cat > "$UNIT_PATH" <<UNIT
+[Unit]
+Description=Android Debug Bridge server (Sushi device tests runner)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=${ADB_USER}
+${SOCKET_DIRECTIVE}
+ExecStart=${EXEC_START}
+ExecStop=${ADB_BIN} kill-server
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+chmod 0644 "$UNIT_PATH"
+
+systemctl daemon-reload
+systemctl enable "${SERVICE_NAME}.service"
+systemctl restart "${SERVICE_NAME}.service"
+
+# Give the daemon a moment to bind.
+sleep 1
+
+systemctl --no-pager --full status "${SERVICE_NAME}.service" || true
+
+echo
+echo "Verifying ADB daemon is reachable..."
+if [ "$ALL_INTERFACES" -eq 1 ]; then
+  CHECK_HOST="127.0.0.1"
+else
+  CHECK_HOST="$BRIDGE_IP"
+fi
+
+if sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices >/dev/null 2>&1; then
+  echo "  OK — adb -H $CHECK_HOST -P $PORT reachable."
+  sudo -u "$ADB_USER" "$ADB_BIN" -H "$CHECK_HOST" -P "$PORT" devices
+else
+  echo "  WARNING — could not reach adb daemon at $CHECK_HOST:$PORT yet." >&2
+  echo "  Check 'journalctl -u ${SERVICE_NAME}.service' for errors." >&2
+fi
+
+echo
+echo "Done. The daemon will start automatically on reboot."
+echo "GitHub Actions runner should set ADB_SERVER_HOST=${CHECK_HOST} and ADB_SERVER_PORT=${PORT}."


### PR DESCRIPTION
Adds scripts/install-adb-systemd-service.sh so the runner host (RPi5)
can be configured with one command instead of the manual recipe in
CI_DEVICE_TESTING.md. The service binds adb to the Docker bridge so
the GitHub Actions container can reach the daemon, survives reboots,
and restarts on failure.

Updates CI_DEVICE_TESTING.md to reference the helper and CLAUDE.md
to list it alongside the other local dev scripts.