### PR TITLE
fix(proguard): use -keep for GeminiTranscriptDatabaseHelper companion reset rule

### DIFF
--- a/app/minified-debug-proguard-rules.pro
+++ b/app/minified-debug-proguard-rules.pro
@@ -20,9 +20,7 @@
 -keepclassmembers class net.hlan.sushi.GeminiTranscriptDatabaseHelper {
     public int clearAll();
 }
--keepclassmembers class net.hlan.sushi.GeminiTranscriptDatabaseHelper$Companion {
-    public void resetInstance();
-}
+-keep class net.hlan.sushi.GeminiTranscriptDatabaseHelper$Companion { void resetInstance(); }
 
 # Keep Kotlin helpers required by AndroidX instrumentation startup in minifiedDebug.
 -keep class kotlin.LazyKt { *; }


### PR DESCRIPTION
## Summary

- Follow-up to gemini-code-assist's high-priority review comment on #117
- PR #117's merged fix (commit `fb25fab`) already retargeted the `resetInstance()` keep rule to `GeminiTranscriptDatabaseHelper$Companion`, but used `-keepclassmembers` instead of `-keep`
- This aligns it with the identical pattern already used for `PhraseDatabaseHelper$Companion` and `PlayDatabaseHelper$Companion`, giving a direct guarantee the method survives R8 shrinking rather than relying on the companion class being kept for other reasons

## Test plan

- [ ] Run `./gradlew connectedDebugAndroidTest` — `GeminiTranscriptDatabaseHelperTest` should remain green


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqnWXp1k2wTpY1J8jBfyTn)_