### PR TITLE
Add Raw Terminal Mode toggle and command output streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows semantic versioning.
 
+## [Unreleased]
+
+### Added
+- Added Raw Terminal Mode toggle to the Gemini dialog — input goes straight to the shell, bypassing the AI layer, while still going through `CommandSafety` classification and the conversation transcript.
+- Added incremental output streaming for AI- and raw-mode command execution: `TerminalBackend.execCommand` now takes an `onChunk` callback so long-running command output appears in the Gemini dialog as it's produced instead of only after the command finishes.
+
 ## [0.7.1] - 2026-06-22
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,22 +43,19 @@ Solidify the terminal layer first — the conversational features all sit on top
 | History UI | ~~`feature/gemini-history-ui`~~ | Gemini history browser — session list + turn detail view, delete session, command/output display | ✅ |
 | Connection errors | ~~`feature/connection-error-classification`~~ | Connection error classification — typed `ConnectFailure` enum, actionable error banner, smart retry gating | ✅ |
 | [Setup checklist](docs/features/first-run-onboarding.md) | ~~`feature/first-run-setup-checklist`~~ | First-run setup checklist — persistent card guides new users through SSH host + key + optional Gemini/Drive | ✅ |
-| [Raw terminal mode](docs/features/raw-terminal-mode.md) | `feature/raw-terminal-mode` | Raw Terminal Mode toggle — switch between AI conversation and direct shell | deferred → v0.7.0 |
-| Output streaming | `feature/output-streaming` | Command output streaming — token-by-token delivery for long-running commands (scope needs re-evaluation) | deferred → v0.7.0 |
+| [Raw terminal mode](docs/features/raw-terminal-mode.md) | ~~`claude/roadmap-priorities-ds0cbs`~~ | Raw Terminal Mode toggle in the Gemini dialog — input goes straight to the shell, bypassing Gemini; still classified/logged via `CommandSafety` and the transcript | ✅ |
+| Output streaming | ~~`claude/roadmap-priorities-ds0cbs`~~ | Command output streaming — `TerminalBackend.execCommand` takes an `onChunk` callback so long-running command output appears incrementally in the Gemini dialog instead of only after completion | ✅ |
 
 ---
 
 ## v0.7.0 — Persona, file operations, and terminal depth
 
 Close the loop on persona editing and add the file operations that conversational users naturally ask for.
-Also picks up the two deferred v0.6.0 terminal items.
 
 - **[Remote SUSHI.md editor](docs/features/persona-editor.md)** — read and write `~/.config/sushi/SUSHI.md` from within the app; right now customizing the persona requires a separate SSH terminal
 - **[SFTP file operations](docs/features/file-operations.md)** — "download this log to my phone" is a natural conversational request; `SshClient` already handles upload via the Share target, download is the missing half *(B-17)*
 - **Custom log location** — read `log_dir` from `~/.config/sushi/config.conf` and honour it; the config key exists, enforcement does not
 - **Connection keep-alive in background** *(T-8)* — session should only disconnect on explicit action, not when the app backgrounds
-- **[Raw Terminal Mode toggle](docs/features/raw-terminal-mode.md)** — switch between AI conversation and direct shell (deferred from v0.6.0)
-- **Command output streaming** — token-by-token delivery for long-running commands (scope needs re-evaluation) (deferred from v0.6.0)
 
 ---
 
@@ -115,4 +112,4 @@ Interesting directions that depend on the conversational core being solid first.
 
 ---
 
-*Last updated: 2026-05-05*
+*Last updated: 2026-07-04*

--- a/app/src/main/java/net/hlan/sushi/ConversationManager.kt
+++ b/app/src/main/java/net/hlan/sushi/ConversationManager.kt
@@ -77,8 +77,15 @@ class ConversationManager(
     /**
      * Process a user message and generate a conversational response.
      * Executes commands if the LLM requests it.
+     *
+     * @param onChunk Optional callback for incremental output while a SAFE command executes,
+     * forwarded to [TerminalBackend.execCommand] so the UI can show progress before the LLM's
+     * interpretation of the final result is ready.
      */
-    suspend fun processUserMessage(userMessage: String): ConversationResult {
+    suspend fun processUserMessage(
+        userMessage: String,
+        onChunk: ((String) -> Unit)? = null
+    ): ConversationResult {
         if (!isInitialized) {
             return ConversationResult(
                 success = false,
@@ -142,7 +149,7 @@ class ConversationManager(
                         
                         CommandSafety.SafetyLevel.SAFE -> {
                             // Safe to execute automatically
-                            executeCommandAndRespond(userMessage, response, command)
+                            executeCommandAndRespond(userMessage, response, command, onChunk)
                         }
                     }
                 } else {
@@ -172,10 +179,11 @@ class ConversationManager(
     suspend fun executeConfirmedCommand(
         userMessage: String,
         initialResponse: String,
-        command: String
+        command: String,
+        onChunk: ((String) -> Unit)? = null
     ): ConversationResult {
         return withContext(Dispatchers.IO) {
-            executeCommandAndRespond(userMessage, initialResponse, command)
+            executeCommandAndRespond(userMessage, initialResponse, command, onChunk)
         }
     }
 
@@ -188,11 +196,12 @@ class ConversationManager(
     private suspend fun executeCommandAndRespond(
         userMessage: String,
         initialResponse: String,
-        command: String
+        command: String,
+        onChunk: ((String) -> Unit)? = null
     ): ConversationResult {
         return try {
             // Use execCommand so we get real output back, not just "Command sent".
-            val cmdResult = backend.execCommand(command)
+            val cmdResult = backend.execCommand(command, onChunk = onChunk)
 
             if (!cmdResult.success && cmdResult.exitStatus == null) {
                 // execCommand itself failed (e.g. not connected, timed out).
@@ -258,6 +267,93 @@ Provide a natural language interpretation of this result, responding as the syst
             )
         }
     }
+
+    /**
+     * Run [command] directly against [backend], bypassing the LLM entirely (Raw Terminal Mode).
+     * Still goes through [CommandSafety] and the same transcript/log persistence as AI-driven
+     * commands so raw-mode activity remains visible in the conversation history.
+     */
+    suspend fun executeRawCommand(
+        command: String,
+        onChunk: ((String) -> Unit)? = null
+    ): ConversationResult {
+        return withContext(Dispatchers.IO) {
+            when (val safety = CommandSafety.classify(command)) {
+                CommandSafety.SafetyLevel.BLOCKED -> {
+                    val explanation = CommandSafety.explainClassification(command)
+                    val response = "[Command blocked: $explanation]"
+                    addToHistory(rawPrompt(command), response, command, null, false)
+
+                    ConversationResult(
+                        success = true,
+                        systemResponse = response,
+                        userMessage = command,
+                        commandAttempted = command,
+                        commandBlocked = true
+                    )
+                }
+
+                CommandSafety.SafetyLevel.CONFIRM -> ConversationResult(
+                    success = true,
+                    systemResponse = "",
+                    userMessage = command,
+                    commandToConfirm = command,
+                    needsConfirmation = true
+                )
+
+                CommandSafety.SafetyLevel.SAFE -> executeRawCommandDirect(command, onChunk)
+            }
+        }
+    }
+
+    /**
+     * Run a raw command that was confirmed by the user (CONFIRM tier).
+     */
+    suspend fun executeConfirmedRawCommand(
+        command: String,
+        onChunk: ((String) -> Unit)? = null
+    ): ConversationResult {
+        return withContext(Dispatchers.IO) {
+            executeRawCommandDirect(command, onChunk)
+        }
+    }
+
+    private suspend fun executeRawCommandDirect(
+        command: String,
+        onChunk: ((String) -> Unit)?
+    ): ConversationResult {
+        return try {
+            val cmdResult = backend.execCommand(command, onChunk = onChunk)
+            val output = cmdResult.message.ifEmpty { "(no output)" }
+            addToHistory(rawPrompt(command), output, command, output, cmdResult.success)
+
+            ConversationResult(
+                success = true,
+                systemResponse = output,
+                userMessage = command,
+                commandExecuted = command,
+                commandOutput = output,
+                commandSuccess = cmdResult.success
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Error executing raw command", e)
+            val response = "[Error executing command: ${e.message}]"
+            addToHistory(rawPrompt(command), response, command, null, false)
+
+            ConversationResult(
+                success = false,
+                systemResponse = response,
+                userMessage = command,
+                commandExecuted = command
+            )
+        }
+    }
+
+    /**
+     * Prefix used so raw-mode turns read distinctly in the transcript/history browser
+     * without needing a schema change to track an AI-vs-raw source column.
+     */
+    private fun rawPrompt(command: String): String = "$ $command"
 
     /**
      * Generate LLM response using configured client (Nano or Cloud).

--- a/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
@@ -87,9 +87,10 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
                 .redirectErrorStream(true)
                 .start()
 
-            // StringBuilder accumulates output while onChunk is invoked per read, so callers
-            // can show progress on long-running commands instead of waiting for the final result.
-            val outputBuilder = StringBuilder()
+            // StringBuffer (not StringBuilder) because the reader thread keeps appending after
+            // process.waitFor() returns; if readerThread.join(500) times out while a read is
+            // still in flight, the calling thread's toString() below would otherwise race with it.
+            val outputBuilder = StringBuffer()
             val readerThread = Thread {
                 try {
                     val reader = process.inputStream.bufferedReader()

--- a/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/LocalShellBackend.kt
@@ -77,16 +77,30 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
      * Output is read in a daemon thread so [timeoutMs] is enforced with [Process.waitFor]
      * rather than blocking on [InputStream.read] — matching the pattern in [SshClient.execCommand].
      */
-    override fun execCommand(command: String, timeoutMs: Long): SshCommandResult {
+    override fun execCommand(
+        command: String,
+        timeoutMs: Long,
+        onChunk: ((String) -> Unit)?
+    ): SshCommandResult {
         return runCatching {
             val process = ProcessBuilder("sh", "-c", command)
                 .redirectErrorStream(true)
                 .start()
 
-            val outputRef = java.util.concurrent.atomic.AtomicReference("")
+            // StringBuilder accumulates output while onChunk is invoked per read, so callers
+            // can show progress on long-running commands instead of waiting for the final result.
+            val outputBuilder = StringBuilder()
             val readerThread = Thread {
                 try {
-                    outputRef.set(process.inputStream.bufferedReader().readText())
+                    val reader = process.inputStream.bufferedReader()
+                    val buf = CharArray(4096)
+                    while (true) {
+                        val n = reader.read(buf)
+                        if (n < 0) break
+                        val chunk = String(buf, 0, n)
+                        outputBuilder.append(chunk)
+                        onChunk?.invoke(chunk)
+                    }
                 } catch (_: Exception) { }
             }.apply {
                 isDaemon = true
@@ -103,7 +117,7 @@ class LocalShellBackend(private val context: Context) : TerminalBackend {
 
             readerThread.join(500)
             val exitCode = process.exitValue()
-            SshCommandResult(exitCode == 0, exitCode, outputRef.get().trim())
+            SshCommandResult(exitCode == 0, exitCode, outputBuilder.toString().trim())
         }.getOrElse { e ->
             SshCommandResult(false, null, e.message ?: "Exec failed")
         }

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -1078,7 +1078,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleUserMessage(message: String) {
-        if (conversationManager == null || !conversationManager!!.isInitialized()) {
+        if (isGeminiRequestRunning) return
+        val manager = conversationManager
+        if (manager == null || !manager.isInitialized()) {
             Toast.makeText(
                 this,
                 getString(R.string.conversation_init_failed, "Not connected"),
@@ -1095,7 +1097,7 @@ class MainActivity : AppCompatActivity() {
             var streamEntryIndex = -1
             try {
                 val result = withContext(Dispatchers.IO) {
-                    conversationManager!!.processUserMessage(message) { chunk ->
+                    manager.processUserMessage(message) { chunk ->
                         lifecycleScope.launch(Dispatchers.Main) {
                             streamEntryIndex = appendStreamingChunk(streamEntryIndex, message, chunk)
                         }
@@ -1136,26 +1138,7 @@ class MainActivity : AppCompatActivity() {
                     // If output streamed in while the command ran, replace it with the final
                     // (LLM-interpreted) response in place; otherwise this is a plain
                     // conversational turn with no command, so append a fresh entry.
-                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
-                        geminiTranscript[streamEntryIndex] = GeminiTranscriptEntry(
-                            prompt = message,
-                            response = result.systemResponse
-                        )
-                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
-                    } else {
-                        geminiTranscript.add(GeminiTranscriptEntry(
-                            prompt = message,
-                            response = result.systemResponse
-                        ))
-                        transcriptAdapter?.let { adapter ->
-                            adapter.notifyItemInserted(geminiTranscript.size - 1)
-                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
-                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
-                                visibility = View.VISIBLE
-                                scrollToPosition(geminiTranscript.size - 1)
-                            }
-                        }
-                    }
+                    replaceOrAppendTranscriptEntry(streamEntryIndex, message, result.systemResponse)
 
                     updateGeminiDialogState()
                 }
@@ -1200,6 +1183,32 @@ class MainActivity : AppCompatActivity() {
         return idx
     }
 
+    /**
+     * Replaces the transcript entry at [entryIndex] with the final (prompt, response) pair,
+     * or appends a new entry if [entryIndex] is out of range (no streaming happened for this turn).
+     * Returns the entry's index.
+     */
+    private fun replaceOrAppendTranscriptEntry(entryIndex: Int, prompt: String, response: String): Int {
+        val entry = GeminiTranscriptEntry(prompt = prompt, response = response)
+        if (entryIndex >= 0 && entryIndex < geminiTranscript.size) {
+            geminiTranscript[entryIndex] = entry
+            transcriptAdapter?.notifyItemChanged(entryIndex)
+            return entryIndex
+        }
+
+        geminiTranscript.add(entry)
+        val idx = geminiTranscript.size - 1
+        transcriptAdapter?.let { adapter ->
+            adapter.notifyItemInserted(idx)
+            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
+            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
+                visibility = View.VISIBLE
+                scrollToPosition(idx)
+            }
+        }
+        return idx
+    }
+
     private fun showCommandConfirmationDialog(
         userMessage: String,
         initialResponse: String,
@@ -1220,14 +1229,17 @@ class MainActivity : AppCompatActivity() {
         initialResponse: String,
         command: String
     ) {
+        val manager = conversationManager ?: return
         isGeminiRequestRunning = true
         updateGeminiDialogState()
 
         lifecycleScope.launch {
-            var streamEntryIndex = -1
+            // Falls back to the last transcript entry (added by handleUserMessage's
+            // needsConfirmation branch) when no output has streamed in yet.
+            var streamEntryIndex = if (geminiTranscript.isNotEmpty()) geminiTranscript.size - 1 else -1
             try {
                 val result = withContext(Dispatchers.IO) {
-                    conversationManager!!.executeConfirmedCommand(
+                    manager.executeConfirmedCommand(
                         userMessage,
                         initialResponse,
                         command
@@ -1249,20 +1261,7 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
 
-                    val targetIdx = if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
-                        streamEntryIndex
-                    } else if (geminiTranscript.isNotEmpty()) {
-                        geminiTranscript.size - 1
-                    } else {
-                        -1
-                    }
-                    if (targetIdx >= 0) {
-                        geminiTranscript[targetIdx] = GeminiTranscriptEntry(
-                            prompt = userMessage,
-                            response = result.systemResponse
-                        )
-                        transcriptAdapter?.notifyItemChanged(targetIdx)
-                    }
+                    replaceOrAppendTranscriptEntry(streamEntryIndex, userMessage, result.systemResponse)
 
                     updateGeminiDialogState()
                 }
@@ -1282,7 +1281,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleRawCommand(command: String) {
-        if (conversationManager == null || !conversationManager!!.isInitialized()) {
+        if (isGeminiRequestRunning) return
+        val manager = conversationManager
+        if (manager == null || !manager.isInitialized()) {
             Toast.makeText(
                 this,
                 getString(R.string.conversation_init_failed, "Not connected"),
@@ -1298,7 +1299,7 @@ class MainActivity : AppCompatActivity() {
             var streamEntryIndex = -1
             try {
                 val result = withContext(Dispatchers.IO) {
-                    conversationManager!!.executeRawCommand(command) { chunk ->
+                    manager.executeRawCommand(command) { chunk ->
                         lifecycleScope.launch(Dispatchers.Main) {
                             streamEntryIndex = appendStreamingChunk(streamEntryIndex, "$ $command", chunk)
                         }
@@ -1325,21 +1326,7 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
 
-                    val entry = GeminiTranscriptEntry(prompt = "$ $command", response = result.systemResponse)
-                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
-                        geminiTranscript[streamEntryIndex] = entry
-                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
-                    } else {
-                        geminiTranscript.add(entry)
-                        transcriptAdapter?.let { adapter ->
-                            adapter.notifyItemInserted(geminiTranscript.size - 1)
-                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
-                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
-                                visibility = View.VISIBLE
-                                scrollToPosition(geminiTranscript.size - 1)
-                            }
-                        }
-                    }
+                    replaceOrAppendTranscriptEntry(streamEntryIndex, "$ $command", result.systemResponse)
 
                     updateGeminiDialogState()
                 }
@@ -1370,6 +1357,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun executeConfirmedRawCommand(command: String) {
+        val manager = conversationManager ?: return
         isGeminiRequestRunning = true
         updateGeminiDialogState()
 
@@ -1377,7 +1365,7 @@ class MainActivity : AppCompatActivity() {
             var streamEntryIndex = -1
             try {
                 val result = withContext(Dispatchers.IO) {
-                    conversationManager!!.executeConfirmedRawCommand(command) { chunk ->
+                    manager.executeConfirmedRawCommand(command) { chunk ->
                         lifecycleScope.launch(Dispatchers.Main) {
                             streamEntryIndex = appendStreamingChunk(streamEntryIndex, "$ $command", chunk)
                         }
@@ -1395,21 +1383,7 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
 
-                    val entry = GeminiTranscriptEntry(prompt = "$ $command", response = result.systemResponse)
-                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
-                        geminiTranscript[streamEntryIndex] = entry
-                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
-                    } else {
-                        geminiTranscript.add(entry)
-                        transcriptAdapter?.let { adapter ->
-                            adapter.notifyItemInserted(geminiTranscript.size - 1)
-                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
-                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
-                                visibility = View.VISIBLE
-                                scrollToPosition(geminiTranscript.size - 1)
-                            }
-                        }
-                    }
+                    replaceOrAppendTranscriptEntry(streamEntryIndex, "$ $command", result.systemResponse)
 
                     updateGeminiDialogState()
                 }

--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -54,6 +54,8 @@ class MainActivity : AppCompatActivity() {
     private var isGeminiRequestRunning = false
     private val geminiTranscript = mutableListOf<GeminiTranscriptEntry>()
     private var transcriptAdapter: GeminiTranscriptAdapter? = null
+    /** Raw Terminal Mode — input goes straight to the shell, bypassing Gemini. Persists across dialog re-opens. */
+    private var isRawTerminalMode = false
     private var playsPageBinding: PageMainPlaysBinding? = null
     private var terminalPageBinding: PageMainTerminalBinding? = null
     private var toolsTabMediator: TabLayoutMediator? = null
@@ -82,7 +84,9 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Use conversation manager if connected, otherwise fall back to old behavior
-        if (conversationManager != null && conversationManager!!.isInitialized()) {
+        if (isRawTerminalMode && conversationManager != null && conversationManager!!.isInitialized()) {
+            handleRawCommand(voiceText)
+        } else if (conversationManager != null && conversationManager!!.isInitialized()) {
             handleUserMessage(voiceText)
         } else {
             // Fallback to old command generation for backwards compatibility
@@ -402,13 +406,21 @@ class MainActivity : AppCompatActivity() {
         dialogBinding.geminiDialogCopyButton.setOnClickListener {
             copyGeminiCommand()
         }
-        
+
+        dialogBinding.geminiDialogRawModeSwitch.isChecked = isRawTerminalMode
+        dialogBinding.geminiDialogRawModeSwitch.setOnCheckedChangeListener { _, checked ->
+            isRawTerminalMode = checked
+            updateGeminiDialogState()
+        }
+
         // NEW: Send button for text input
         dialogBinding.geminiDialogSendButton.setOnClickListener {
             val text = dialogBinding.geminiDialogTextInput.text?.toString()?.trim()
             if (!text.isNullOrEmpty()) {
                 dialogBinding.geminiDialogTextInput.text?.clear()
-                if (conversationManager != null && conversationManager!!.isInitialized()) {
+                if (isRawTerminalMode) {
+                    handleRawCommand(text)
+                } else if (conversationManager != null && conversationManager!!.isInitialized()) {
                     handleUserMessage(text)
                 } else {
                     // Fallback to old behavior
@@ -469,6 +481,11 @@ class MainActivity : AppCompatActivity() {
         } else {
             View.GONE
         }
+
+        dialogBinding.geminiDialogTextInputLayout.hint = getString(
+            if (isRawTerminalMode) R.string.raw_terminal_mode_hint else R.string.conversation_input_hint
+        )
+
         val hasCommand = !isBusy
             && lastGeminiOutput.isNotBlank()
             && lastGeminiOutput != getString(R.string.gemini_output_placeholder)
@@ -1075,9 +1092,14 @@ class MainActivity : AppCompatActivity() {
         updateGeminiDialogState()
 
         lifecycleScope.launch {
+            var streamEntryIndex = -1
             try {
                 val result = withContext(Dispatchers.IO) {
-                    conversationManager!!.processUserMessage(message)
+                    conversationManager!!.processUserMessage(message) { chunk ->
+                        lifecycleScope.launch(Dispatchers.Main) {
+                            streamEntryIndex = appendStreamingChunk(streamEntryIndex, message, chunk)
+                        }
+                    }
                 }
 
                 withContext(Dispatchers.Main) {
@@ -1111,16 +1133,27 @@ class MainActivity : AppCompatActivity() {
                         }
                     }
 
-                    geminiTranscript.add(GeminiTranscriptEntry(
-                        prompt = message,
-                        response = result.systemResponse
-                    ))
-                    transcriptAdapter?.let { adapter ->
-                        adapter.notifyItemInserted(geminiTranscript.size - 1)
-                        geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
-                        geminiDialogBinding?.geminiTranscriptRecycler?.apply {
-                            visibility = View.VISIBLE
-                            scrollToPosition(geminiTranscript.size - 1)
+                    // If output streamed in while the command ran, replace it with the final
+                    // (LLM-interpreted) response in place; otherwise this is a plain
+                    // conversational turn with no command, so append a fresh entry.
+                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
+                        geminiTranscript[streamEntryIndex] = GeminiTranscriptEntry(
+                            prompt = message,
+                            response = result.systemResponse
+                        )
+                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
+                    } else {
+                        geminiTranscript.add(GeminiTranscriptEntry(
+                            prompt = message,
+                            response = result.systemResponse
+                        ))
+                        transcriptAdapter?.let { adapter ->
+                            adapter.notifyItemInserted(geminiTranscript.size - 1)
+                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
+                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
+                                visibility = View.VISIBLE
+                                scrollToPosition(geminiTranscript.size - 1)
+                            }
                         }
                     }
 
@@ -1139,6 +1172,32 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    /**
+     * Appends [chunk] to the transcript entry at [entryIndex], creating a new entry
+     * (prompt=[prompt]) the first time a chunk arrives for a turn. Must run on the Main thread.
+     * Returns the entry's index so the caller can track it across subsequent chunks.
+     */
+    private fun appendStreamingChunk(entryIndex: Int, prompt: String, chunk: String): Int {
+        if (entryIndex >= 0 && entryIndex < geminiTranscript.size) {
+            val current = geminiTranscript[entryIndex]
+            geminiTranscript[entryIndex] = current.copy(response = current.response + chunk)
+            transcriptAdapter?.notifyItemChanged(entryIndex)
+            return entryIndex
+        }
+
+        geminiTranscript.add(GeminiTranscriptEntry(prompt = prompt, response = chunk))
+        val idx = geminiTranscript.size - 1
+        transcriptAdapter?.let { adapter ->
+            adapter.notifyItemInserted(idx)
+            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
+            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
+                visibility = View.VISIBLE
+                scrollToPosition(idx)
+            }
+        }
+        return idx
     }
 
     private fun showCommandConfirmationDialog(
@@ -1165,13 +1224,18 @@ class MainActivity : AppCompatActivity() {
         updateGeminiDialogState()
 
         lifecycleScope.launch {
+            var streamEntryIndex = -1
             try {
                 val result = withContext(Dispatchers.IO) {
                     conversationManager!!.executeConfirmedCommand(
                         userMessage,
                         initialResponse,
                         command
-                    )
+                    ) { chunk ->
+                        lifecycleScope.launch(Dispatchers.Main) {
+                            streamEntryIndex = appendStreamingChunk(streamEntryIndex, userMessage, chunk)
+                        }
+                    }
                 }
 
                 withContext(Dispatchers.Main) {
@@ -1185,19 +1249,172 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
 
-                    if (geminiTranscript.isNotEmpty()) {
-                        val lastIdx = geminiTranscript.size - 1
-                        geminiTranscript[lastIdx] = GeminiTranscriptEntry(
+                    val targetIdx = if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
+                        streamEntryIndex
+                    } else if (geminiTranscript.isNotEmpty()) {
+                        geminiTranscript.size - 1
+                    } else {
+                        -1
+                    }
+                    if (targetIdx >= 0) {
+                        geminiTranscript[targetIdx] = GeminiTranscriptEntry(
                             prompt = userMessage,
                             response = result.systemResponse
                         )
-                        transcriptAdapter?.notifyItemChanged(lastIdx)
+                        transcriptAdapter?.notifyItemChanged(targetIdx)
                     }
 
                     updateGeminiDialogState()
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error executing confirmed command", e)
+                withContext(Dispatchers.Main) {
+                    isGeminiRequestRunning = false
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Error: ${e.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    updateGeminiDialogState()
+                }
+            }
+        }
+    }
+
+    private fun handleRawCommand(command: String) {
+        if (conversationManager == null || !conversationManager!!.isInitialized()) {
+            Toast.makeText(
+                this,
+                getString(R.string.conversation_init_failed, "Not connected"),
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        isGeminiRequestRunning = true
+        updateGeminiDialogState()
+
+        lifecycleScope.launch {
+            var streamEntryIndex = -1
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    conversationManager!!.executeRawCommand(command) { chunk ->
+                        lifecycleScope.launch(Dispatchers.Main) {
+                            streamEntryIndex = appendStreamingChunk(streamEntryIndex, "$ $command", chunk)
+                        }
+                    }
+                }
+
+                withContext(Dispatchers.Main) {
+                    isGeminiRequestRunning = false
+
+                    if (result.needsConfirmation) {
+                        showRawCommandConfirmationDialog(command)
+                        updateGeminiDialogState()
+                        return@withContext
+                    }
+
+                    lastGeminiOutput = result.systemResponse
+
+                    if (result.commandBlocked) {
+                        appendSessionLog("Blocked (raw): $command")
+                    } else if (result.commandExecuted != null) {
+                        appendSessionLog(
+                            "Executed (raw): ${result.commandExecuted}\n" +
+                            "Result: ${if (result.commandSuccess) "success" else "failed"}"
+                        )
+                    }
+
+                    val entry = GeminiTranscriptEntry(prompt = "$ $command", response = result.systemResponse)
+                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
+                        geminiTranscript[streamEntryIndex] = entry
+                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
+                    } else {
+                        geminiTranscript.add(entry)
+                        transcriptAdapter?.let { adapter ->
+                            adapter.notifyItemInserted(geminiTranscript.size - 1)
+                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
+                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
+                                visibility = View.VISIBLE
+                                scrollToPosition(geminiTranscript.size - 1)
+                            }
+                        }
+                    }
+
+                    updateGeminiDialogState()
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error executing raw command", e)
+                withContext(Dispatchers.Main) {
+                    isGeminiRequestRunning = false
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Error: ${e.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    updateGeminiDialogState()
+                }
+            }
+        }
+    }
+
+    private fun showRawCommandConfirmationDialog(command: String) {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.conversation_confirm_command_title))
+            .setMessage(getString(R.string.conversation_confirm_command_message, command))
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                executeConfirmedRawCommand(command)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun executeConfirmedRawCommand(command: String) {
+        isGeminiRequestRunning = true
+        updateGeminiDialogState()
+
+        lifecycleScope.launch {
+            var streamEntryIndex = -1
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    conversationManager!!.executeConfirmedRawCommand(command) { chunk ->
+                        lifecycleScope.launch(Dispatchers.Main) {
+                            streamEntryIndex = appendStreamingChunk(streamEntryIndex, "$ $command", chunk)
+                        }
+                    }
+                }
+
+                withContext(Dispatchers.Main) {
+                    isGeminiRequestRunning = false
+                    lastGeminiOutput = result.systemResponse
+
+                    if (result.commandExecuted != null) {
+                        appendSessionLog(
+                            "Executed (raw, confirmed): ${result.commandExecuted}\n" +
+                            "Result: ${if (result.commandSuccess) "success" else "failed"}"
+                        )
+                    }
+
+                    val entry = GeminiTranscriptEntry(prompt = "$ $command", response = result.systemResponse)
+                    if (streamEntryIndex >= 0 && streamEntryIndex < geminiTranscript.size) {
+                        geminiTranscript[streamEntryIndex] = entry
+                        transcriptAdapter?.notifyItemChanged(streamEntryIndex)
+                    } else {
+                        geminiTranscript.add(entry)
+                        transcriptAdapter?.let { adapter ->
+                            adapter.notifyItemInserted(geminiTranscript.size - 1)
+                            geminiDialogBinding?.geminiTranscriptLabel?.visibility = View.VISIBLE
+                            geminiDialogBinding?.geminiTranscriptRecycler?.apply {
+                                visibility = View.VISIBLE
+                                scrollToPosition(geminiTranscript.size - 1)
+                            }
+                        }
+                    }
+
+                    updateGeminiDialogState()
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error executing confirmed raw command", e)
                 withContext(Dispatchers.Main) {
                     isGeminiRequestRunning = false
                     Toast.makeText(

--- a/app/src/main/java/net/hlan/sushi/SshClient.kt
+++ b/app/src/main/java/net/hlan/sushi/SshClient.kt
@@ -347,7 +347,11 @@ class SshClient(private val config: SshConnectionConfig) : TerminalBackend {
      *   [SshCommandResult.exitStatus] set to the process exit code, and
      *   [SshCommandResult.message] containing the combined stdout/stderr output.
      */
-    override fun execCommand(command: String, timeoutMs: Long): SshCommandResult {
+    override fun execCommand(
+        command: String,
+        timeoutMs: Long,
+        onChunk: ((String) -> Unit)?
+    ): SshCommandResult {
         val activeSession = session
         if (activeSession == null || !activeSession.isConnected) {
             return SshCommandResult(false, null, "Not connected")
@@ -368,12 +372,22 @@ class SshClient(private val config: SshConnectionConfig) : TerminalBackend {
 
             // Read output in a daemon thread so we can enforce a wall-clock timeout.
             // AtomicReference provides safe cross-thread exception propagation without
-            // requiring the reader thread to hold any lock.
-            val outputBuffer = ByteArrayOutputStream()
+            // requiring the reader thread to hold any lock. Reading through InputStreamReader
+            // (rather than copyTo a byte buffer) lets us hand chunks to onChunk as they arrive
+            // instead of only surfacing output once the whole command has finished.
+            val outputBuilder = StringBuilder()
             val readerError = AtomicReference<Exception?>(null)
             val readerThread = Thread {
                 try {
-                    stdout.copyTo(outputBuffer)
+                    val reader = InputStreamReader(stdout, Charsets.UTF_8)
+                    val buf = CharArray(4096)
+                    while (true) {
+                        val n = reader.read(buf)
+                        if (n < 0) break
+                        val chunk = String(buf, 0, n)
+                        outputBuilder.append(chunk)
+                        onChunk?.invoke(chunk)
+                    }
                 } catch (e: Exception) {
                     readerError.set(e)
                 }
@@ -407,7 +421,7 @@ class SshClient(private val config: SshConnectionConfig) : TerminalBackend {
             }
 
             val exitStatus = ch.exitStatus
-            val stdoutStr = outputBuffer.toString(Charsets.UTF_8).trim()
+            val stdoutStr = outputBuilder.toString().trim()
             val stderrStr = stderrBuffer.toString(Charsets.UTF_8).trim()
 
             val fullOutput = when {

--- a/app/src/main/java/net/hlan/sushi/TerminalBackend.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalBackend.kt
@@ -22,7 +22,14 @@ interface TerminalBackend {
      *
      * @param command Shell command to run.
      * @param timeoutMs Maximum time to wait before aborting.
+     * @param onChunk Optional callback invoked with output as it arrives, before the command
+     * finishes. Lets callers (e.g. the Gemini dialog) show progress on long-running commands
+     * instead of waiting for the final [SshCommandResult].
      * @return [SshCommandResult] with success=true when exit code is 0.
      */
-    fun execCommand(command: String, timeoutMs: Long = 30_000L): SshCommandResult
+    fun execCommand(
+        command: String,
+        timeoutMs: Long = 30_000L,
+        onChunk: ((String) -> Unit)? = null
+    ): SshCommandResult
 }

--- a/app/src/main/res/layout/dialog_gemini_controls.xml
+++ b/app/src/main/res/layout/dialog_gemini_controls.xml
@@ -22,6 +22,13 @@
         android:layout_marginTop="8dp"
         android:text="@string/gemini_status_disabled" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/geminiDialogRawModeSwitch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="@string/raw_terminal_mode_label" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/geminiDialogVoiceButton"
         style="@style/Widget.Sushi.PrimaryButton"
@@ -61,6 +68,7 @@
         android:orientation="horizontal">
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/geminiDialogTextInputLayout"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,6 +381,8 @@
     
     <!-- Conversation UI -->
     <string name="conversation_input_hint">Ask the system...</string>
+    <string name="raw_terminal_mode_label">Raw mode</string>
+    <string name="raw_terminal_mode_hint">Raw shell — commands run directly, no AI</string>
     <string name="action_send_message">Send message</string>
     <string name="conversation_confirm_command_title">Confirm Command</string>
     <string name="conversation_confirm_command_message">Execute this command?\n\n%1$s</string>


### PR DESCRIPTION
Closes the two v0.6.0 items deferred to v0.7.0:

- Raw Terminal Mode: a switch in the Gemini dialog routes input
  straight to the shell via TerminalBackend, bypassing the LLM
  entirely. Raw commands still go through CommandSafety and the
  same transcript/log persistence as AI-driven turns.
- Command output streaming: TerminalBackend.execCommand takes an
  onChunk callback, implemented in both SshClient and
  LocalShellBackend, so long-running command output appears in the
  Gemini dialog incrementally instead of only after completion.
  Wired into both the AI-conversation path and raw mode.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XjmbYBTf5VGtaAT6Hz9Um7