### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows semantic versioning.
 
-## [Unreleased]
+## [0.7.2] - 2026-07-05
 
 ### Added
 - Added Raw Terminal Mode toggle to the Gemini dialog — input goes straight to the shell, bypassing the AI layer, while still going through `CommandSafety` classification and the conversation transcript.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "net.hlan.sushi"
         minSdk = 26
         targetSdk = 36
-        versionCode = versionCodeOverride ?: 17
-        versionName = versionNameOverride ?: "0.7.1"
+        versionCode = versionCodeOverride ?: 18
+        versionName = versionNameOverride ?: "0.7.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

Prepare the v0.7.2 release: promote the CHANGELOG's `[Unreleased]` entry to a dated release and bump the app version.

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.7.2] - 2026-07-05` (Raw Terminal Mode toggle + incremental command output streaming, already merged to `main`).
- `app/build.gradle.kts`: `versionCode` 17 → 18, `versionName` "0.7.1" → "0.7.2".

## UI / UX changes

- [ ] Yes — Figma frame linked below
- [x] No — purely logic/backend change

**Figma frame:** N/A

## Test plan

- [ ] Tested on device / emulator
- [x] No regressions in existing flows (version/changelog metadata only)

## Checklist

- [x] User-visible strings added to `strings.xml` (n/a, no new strings)
- [x] No hardcoded secrets
- [x] ProGuard rules updated if new reflection-loaded classes added (n/a, no new classes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EoX9J85hfmmCTLRmFhgPXi)_