### PR TITLE
ci: API 37 emulator workflow + remaining ProGuard fixes

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,9 +59,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - name: Install unzip (required by setup-android)
-        run: sudo apt-get install -y unzip
-
       - name: Set up Android SDK tools (adb)
         uses: android-actions/setup-android@v4
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -1,4 +1,4 @@
-name: Device Tests (RPi5 + Nokia 4.2G)
+name: Device Tests (RPi5 + Nokia 42 5G)
 
 # Optional workflow — never blocks PR merges.
 #

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -75,6 +75,9 @@ jobs:
           # Optional: explicit device address for Wi-Fi ADB (e.g. "192.168.1.42:5555").
           # When set, the step connects via TCP instead of relying on the host server.
           DEVICE_ADDRESS: ${{ secrets.ANDROID_DEVICE_ADDRESS }}
+          # USB serial of the target device — avoids ambiguity when multiple devices
+          # are visible on the host ADB server.
+          DEVICE_SERIAL: ${{ secrets.ANDROID_DEVICE_SERIAL }}
         run: |
           if ! command -v adb >/dev/null 2>&1; then
             echo "::error::'adb' is not installed in the runner container. Add 'android-tools-adb' to the runner image."
@@ -107,9 +110,10 @@ jobs:
           # Persist ADB env for subsequent steps.
           echo "ANDROID_ADB_SERVER_ADDRESS=$ADB_HOST" >> "$GITHUB_ENV"
           echo "ANDROID_ADB_SERVER_PORT=$ADB_PORT"    >> "$GITHUB_ENV"
-          # Always pin ANDROID_SERIAL so subsequent adb calls target the right device
-          # even when multiple devices are visible on the host ADB server.
-          SERIAL="${DEVICE_ADDRESS:-$(adb devices | grep -v "^List" | grep "device$" | head -1 | awk '{print $1}')}"
+          # Pin ANDROID_SERIAL: prefer explicit secret, then DEVICE_ADDRESS, then first device.
+          # The secret is the Nokia G42 5G serial — avoids ambiguity when multiple devices
+          # are visible on the host ADB server.
+          SERIAL="${DEVICE_SERIAL:-${DEVICE_ADDRESS:-$(adb devices | grep -v "^List" | grep "device$" | head -1 | awk '{print $1}')}}"
           echo "ANDROID_SERIAL=$SERIAL" >> "$GITHUB_ENV"
           echo "Targeting device: $SERIAL"
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -107,7 +107,11 @@ jobs:
           # Persist ADB env for subsequent steps.
           echo "ANDROID_ADB_SERVER_ADDRESS=$ADB_HOST" >> "$GITHUB_ENV"
           echo "ANDROID_ADB_SERVER_PORT=$ADB_PORT"    >> "$GITHUB_ENV"
-          [ -n "$DEVICE_ADDRESS" ] && echo "ANDROID_SERIAL=$DEVICE_ADDRESS" >> "$GITHUB_ENV" || true
+          # Always pin ANDROID_SERIAL so subsequent adb calls target the right device
+          # even when multiple devices are visible on the host ADB server.
+          SERIAL="${DEVICE_ADDRESS:-$(adb devices | grep -v "^List" | grep "device$" | head -1 | awk '{print $1}')}"
+          echo "ANDROID_SERIAL=$SERIAL" >> "$GITHUB_ENV"
+          echo "Targeting device: $SERIAL"
 
       - name: Prepare device for instrumented tests
         run: |

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      - name: Install unzip (required by setup-android)
+        run: sudo apt-get install -y unzip
+
       - name: Set up Android SDK tools (adb)
         uses: android-actions/setup-android@v4
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,8 +59,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - name: Set up Android SDK tools (adb)
-        uses: android-actions/setup-android@v4
+      - name: Verify Android SDK (pre-installed in runner image)
+        run: |
+          adb --version
+          echo "ANDROID_HOME=$ANDROID_HOME"
+          sdkmanager --list_installed 2>/dev/null | grep -E "build-tools|platform-tools|platforms" || true
 
       - name: Connect to ADB (host server or Wi-Fi)
         env:

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -101,9 +101,11 @@ jobs:
         id: run_tests
         timeout-minutes: 20
         run: |
+          set -o pipefail
           ./gradlew connectedMinifiedDebugAndroidTest \
             -Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest \
-            --continue
+            --continue --info 2>&1 \
+            | grep --line-buffered -E "(> Task :| STARTED| PASSED| FAILED| SKIPPED|Tests [0-9]+/[0-9]+|Exception|Error:)"
         continue-on-error: true
 
       - name: Stop emulator

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -104,6 +104,7 @@ jobs:
           set -o pipefail
           ./gradlew connectedMinifiedDebugAndroidTest \
             -Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest \
+            -Pandroid.testInstrumentationRunnerArguments.timeout_msec=60000 \
             --continue --info 2>&1 \
             | grep --line-buffered -E "(> Task :| STARTED| PASSED| FAILED| SKIPPED|Tests [0-9]+/[0-9]+|Exception|Error:)"
         continue-on-error: true

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -59,22 +59,20 @@ jobs:
             "emulator"
 
       - name: Create API 37 AVD
-        env:
-          ANDROID_AVD_HOME: ${{ runner.home }}/.android/avd
         run: |
-          mkdir -p "$ANDROID_AVD_HOME"
-          echo no | avdmanager create avd \
+          AVD_HOME="$HOME/.android/avd"
+          mkdir -p "$AVD_HOME"
+          echo "ANDROID_AVD_HOME=$AVD_HOME" >> "$GITHUB_ENV"
+          echo no | ANDROID_AVD_HOME="$AVD_HOME" avdmanager create avd \
             --name "api37" \
             --package "system-images;android-37.0;google_apis_ps16k;x86_64" \
             --device "pixel_6"
-          avdmanager list avd
+          ANDROID_AVD_HOME="$AVD_HOME" avdmanager list avd
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
       - name: Start emulator
-        env:
-          ANDROID_AVD_HOME: ${{ runner.home }}/.android/avd
         run: |
           $ANDROID_HOME/emulator/emulator \
             -avd api37 \

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -101,12 +101,18 @@ jobs:
         id: run_tests
         timeout-minutes: 20
         run: |
-          set -o pipefail
+          # Stream per-test progress from device logcat alongside Gradle output.
+          adb -s emulator-5554 logcat -v time -s TestRunner:I &
+          LOGCAT_PID=$!
+
           ./gradlew connectedMinifiedDebugAndroidTest \
             -Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest \
             -Pandroid.testInstrumentationRunnerArguments.timeout_msec=60000 \
-            --continue --info 2>&1 \
-            | grep --line-buffered -E "(> Task :| STARTED| PASSED| FAILED| SKIPPED|Tests [0-9]+/[0-9]+|Exception|Error:)"
+            --continue
+          GRADLE_EXIT=$?
+
+          kill "$LOGCAT_PID" 2>/dev/null || true
+          exit $GRADLE_EXIT
         continue-on-error: true
 
       - name: Stop emulator

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -106,7 +106,7 @@ jobs:
           LOGCAT_PID=$!
 
           ./gradlew connectedMinifiedDebugAndroidTest \
-            "-Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest,net.hlan.sushi.LocalShellBackendTest" \
+            "-Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest,net.hlan.sushi.LocalShellBackendTest,net.hlan.sushi.DeviceQaSuiteTest" \
             -Pandroid.testInstrumentationRunnerArguments.timeout_msec=60000 \
             --continue
           GRADLE_EXIT=$?

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Run instrumented tests
         id: run_tests
+        timeout-minutes: 20
         run: |
           ./gradlew connectedMinifiedDebugAndroidTest \
             -Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest \

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -59,16 +59,22 @@ jobs:
             "emulator"
 
       - name: Create API 37 AVD
+        env:
+          ANDROID_AVD_HOME: ${{ runner.home }}/.android/avd
         run: |
+          mkdir -p "$ANDROID_AVD_HOME"
           echo no | avdmanager create avd \
             --name "api37" \
             --package "system-images;android-37.0;google_apis_ps16k;x86_64" \
             --device "pixel_6"
+          avdmanager list avd
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
       - name: Start emulator
+        env:
+          ANDROID_AVD_HOME: ${{ runner.home }}/.android/avd
         run: |
           $ANDROID_HOME/emulator/emulator \
             -avd api37 \

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -106,7 +106,7 @@ jobs:
           LOGCAT_PID=$!
 
           ./gradlew connectedMinifiedDebugAndroidTest \
-            -Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest \
+            "-Pandroid.testInstrumentationRunnerArguments.notClass=net.hlan.sushi.LocalSshIntegrationTest,net.hlan.sushi.LocalShellBackendTest" \
             -Pandroid.testInstrumentationRunnerArguments.timeout_msec=60000 \
             --continue
           GRADLE_EXIT=$?

--- a/app/minified-debug-proguard-rules.pro
+++ b/app/minified-debug-proguard-rules.pro
@@ -15,6 +15,12 @@
     public *;
 }
 
+# GeminiTranscriptSessionSummary.lastActivityAt has no production reader (only startedAt is
+# displayed); R8 removes the getter. Keep all public members for test assertions.
+-keepclassmembers class net.hlan.sushi.GeminiTranscriptSessionSummary {
+    public *;
+}
+
 # GeminiTranscriptDatabaseHelper.resetInstance() (companion) and clearAll() (instance) have no
 # production callers; R8 removes them. Keep for test setUp/tearDown.
 -keepclassmembers class net.hlan.sushi.GeminiTranscriptDatabaseHelper {


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs instrumented tests on an API 37 (Android 17) emulator for Pixel 10 / Android 17 regression coverage
- Fixes `GeminiTranscriptSessionSummary.getLastActivityAt()` being stripped by R8 (same root cause as PR #117)
- Excludes tests that require real device PTY or window focus from the emulator job (`LocalShellBackendTest`, `LocalSshIntegrationTest`, `DeviceQaSuiteTest`)
- Adds per-test logcat streaming and timeouts so stuck tests surface immediately

## Key technical notes

- API 37 only ships `ps16k` (16 KB page-size) system images; `reactivecircus/android-emulator-runner` is incompatible (hard-codes wrong package name), so emulator lifecycle is managed manually
- `LocalShellBackend.connect()` blocks indefinitely on the ps16k emulator — PTY tests remain in the Nokia device job only
- `ANDROID_AVD_HOME` must be set via `$HOME` in shell, not `${{ runner.home }}` (evaluates to empty in `workflow_dispatch` context)

## Test plan

- [ ] Emulator workflow runs to completion with 0 unexpected failures
- [ ] `GeminiTranscriptDatabaseHelperTest` passes on emulator
- [ ] `AiConversationTest` and `JschRuntimeTest` pass on emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)