### PR TITLE
fix(res): repair corrupt pathData in ic_content_paste — Android 17 crash

### DIFF
--- a/app/src/androidTest/java/net/hlan/sushi/LayoutInflationTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/LayoutInflationTest.kt
@@ -1,0 +1,42 @@
+package net.hlan.sushi
+
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Inflates activity layouts without launching activities. Catches resource-level
+ * regressions — e.g. corrupt vector pathData that newer Android versions reject
+ * (Android 17's PathParser crashed TerminalActivity on a malformed
+ * ic_content_paste). Runs on the API 37 emulator where the strict parser lives.
+ */
+@RunWith(AndroidJUnit4::class)
+class LayoutInflationTest {
+
+    private fun themedInflater(): LayoutInflater {
+        val context = ContextThemeWrapper(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            R.style.Theme_Sushi
+        )
+        return LayoutInflater.from(context)
+    }
+
+    @Test
+    fun activityTerminalInflates() {
+        assertNotNull(themedInflater().inflate(R.layout.activity_terminal, null))
+    }
+
+    @Test
+    fun activityMainInflates() {
+        assertNotNull(themedInflater().inflate(R.layout.activity_main, null))
+    }
+
+    @Test
+    fun activitySettingsInflates() {
+        assertNotNull(themedInflater().inflate(R.layout.activity_settings, null))
+    }
+}

--- a/app/src/main/res/drawable/ic_content_paste.xml
+++ b/app/src/main/res/drawable/ic_content_paste.xml
@@ -6,5 +6,5 @@
     android:tint="?attr/colorControlNormal">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="width=24,height=24,viewportWidth=24,viewportHeight=24,tint=0x757575FF,pathData=M19,2h-4.18C14.4,0.84 13.3,0 12,0c-1.3,0 -2.4,0.84 -2.82,2L5,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM12,2c0.55,0 1,0.45 1,1s-0.45,1 -1,1 -1,-0.45 -1,-1 0.45,-1 1,-1zM19,20L5,20L5,4h2v3h10L17,4h2v16z"/>
+      android:pathData="M19,2h-4.18C14.4,0.84 13.3,0 12,0c-1.3,0 -2.4,0.84 -2.82,2L5,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM12,2c0.55,0 1,0.45 1,1s-0.45,1 -1,1 -1,-0.45 -1,-1 0.45,-1 1,-1zM19,20L5,20L5,4h2v3h10L17,4h2v16z"/>
 </vector>


### PR DESCRIPTION
## Summary

Fixes the Pixel 10 Pro XL (Android 17) crash on Connect, diagnosed from the Play Console Android vitals stack trace.

**Root cause:** `ic_content_paste.xml` shipped in v0.7.0 with the entire attribute dump pasted into `android:pathData`:

```
android:pathData="width=24,height=24,viewportWidth=24,...,pathData=M19,2h-4.18..."
```

Android ≤ 15 silently tolerates the garbage prefix, but Android 17's stricter `PathParser` throws `IllegalArgumentException`, which crashes `TerminalActivity` during layout inflation (`MaterialButton` → `AppCompatResources.getDrawable` → `VectorDrawable.inflate`). Connect opens `TerminalActivity`, hence the crash right after tapping Connect.

Not related to the dependabot dependency updates — the drawable has been broken since v0.7.0; the crash surfaced when the Pixel moved to Android 17.

## Changes

- Strip the garbage prefix from `ic_content_paste.xml` pathData (the valid Material `content_paste` path was recoverable from the corrupted value)
- Add `LayoutInflationTest` — inflates `activity_terminal`, `activity_main`, and `activity_settings` with the app theme on-device, so the API 37 emulator job catches this class of resource regression

## Test plan

- [x] `compileMinifiedDebugAndroidTestKotlin` + `processDebugResources` pass locally
- [ ] Emulator Tests (API 37) green — `LayoutInflationTest.activityTerminalInflates` reproduces the crash path on Android 17
- [ ] After merge: cut v0.7.3 patch release and verify on the Pixel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENspciP9BCM4PNvkCBXhfw