### PR TITLE
fix(proguard): keep app R classes for test APK runtime resolution

### DIFF
--- a/app/minified-debug-proguard-rules.pro
+++ b/app/minified-debug-proguard-rules.pro
@@ -28,6 +28,11 @@
 }
 -keep class net.hlan.sushi.GeminiTranscriptDatabaseHelper$Companion { void resetInstance(); }
 
+# The test APK resolves app R classes at runtime (androidTest R fields are non-final
+# field references, not inlined constants). R8 strips R classes from the app APK,
+# breaking e.g. LayoutInflationTest with NoClassDefFoundError: R$style.
+-keep class net.hlan.sushi.R$* { *; }
+
 # Keep Kotlin helpers required by AndroidX instrumentation startup in minifiedDebug.
 -keep class kotlin.LazyKt { *; }
 -keep class kotlin.LazyKt__* { *; }


### PR DESCRIPTION
## Summary

Follow-up to #123. The merged `LayoutInflationTest` fails on the API 37 emulator with `NoClassDefFoundError: net.hlan.sushi.R$style` — androidTest R fields are non-final field references resolved against the app APK at runtime, and R8 strips R classes from the minified app APK.

Adds a `-keep class net.hlan.sushi.R$* { *; }` rule to `minified-debug-proguard-rules.pro`. minifiedDebug-only; the release build is unaffected.

## Test plan

- [ ] Emulator Tests (API 37) green — all 33 tests including the three `LayoutInflationTest` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENspciP9BCM4PNvkCBXhfw