### PR TITLE
fix(connection): keep SSH session alive when app is backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog and follows semantic versioning.
 
 ### Fixed
 - Fixed SSH sessions dropping when Sushi is backgrounded: a foreground service (`SshConnectionService`) now keeps the process alive while a terminal session is connected, with a persistent "Session active" notification offering a one-tap disconnect.
+- Fixed `TerminalView` leaking raw OSC escape-sequence payloads (e.g. window-title text like `0;some title`) into the rendered terminal output; OSC sequences are now stripped like the existing CSI ones.
+- Fixed bare `\r` (progress bars, spinners, in-place redraws) being silently dropped instead of overwriting the current line, including when the `\r` and the following character arrive in separate read chunks.
 
 ## [0.7.3] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+- Fixed SSH sessions dropping when Sushi is backgrounded: a foreground service (`SshConnectionService`) now keeps the process alive while a terminal session is connected, with a persistent "Session active" notification offering a one-tap disconnect.
+
 ## [0.7.3] - 2026-07-08
 
 ### Fixed

--- a/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeSequenceTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeSequenceTest.kt
@@ -1,0 +1,55 @@
+package net.hlan.sushi
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TerminalViewEscapeSequenceTest {
+
+    private val esc = "\u001B"
+    private val bel = "\u0007"
+
+    @Test
+    fun oscWindowTitleSequenceIsStripped() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val terminalView = TerminalView(context)
+
+        terminalView.appendLog("$esc]0;some title$bel" + "hello\n")
+
+        assertEquals("hello\n", terminalView.text.toString())
+    }
+
+    @Test
+    fun bareCarriageReturnOverwritesCurrentLine() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val terminalView = TerminalView(context)
+
+        terminalView.appendLog("Loading...\rDone\n")
+
+        assertEquals("Done\n", terminalView.text.toString())
+    }
+
+    @Test
+    fun carriageReturnLineFeedIsARegularLineBreak() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val terminalView = TerminalView(context)
+
+        terminalView.appendLog("abc\r\ndef")
+
+        assertEquals("abc\ndef", terminalView.text.toString())
+    }
+
+    @Test
+    fun pendingCarriageReturnAcrossChunksStillOverwrites() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val terminalView = TerminalView(context)
+
+        terminalView.appendLog("Loading...\r")
+        terminalView.appendLog("Done\n")
+
+        assertEquals("Done\n", terminalView.text.toString())
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <!-- Android 14+ requires a connectedDevice-type foreground service to hold at least one
+         Bluetooth/NFC/USB/Wi-Fi permission; CHANGE_NETWORK_STATE is a normal, auto-granted
+         permission that satisfies this without a runtime prompt. -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
     <application
         android:name=".SushiApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <application
         android:name=".SushiApplication"
@@ -23,6 +26,11 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+
+        <service
+            android:name=".SshConnectionService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/net/hlan/sushi/SshConnectionService.kt
+++ b/app/src/main/java/net/hlan/sushi/SshConnectionService.kt
@@ -1,0 +1,119 @@
+package net.hlan.sushi
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+
+/**
+ * Foreground service that keeps the process (and the JSch reader thread it hosts)
+ * alive while a terminal session is connected. Without this, Android freezes or
+ * kills the app soon after it leaves the foreground and the SSH session drops.
+ *
+ * Ownership of the actual [TerminalBackend] stays in [TerminalSessionHolder]; this
+ * service only holds the foreground-priority notification and reacts to the
+ * connect/disconnect state already tracked there.
+ */
+class SshConnectionService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_DISCONNECT) {
+            TerminalSessionHolder.getActiveBackend()?.disconnect()
+            TerminalSessionHolder.clearActiveConnection()
+            return START_NOT_STICKY
+        }
+
+        ensureChannel()
+        val hostLabel = TerminalSessionHolder.getActiveConfig()?.displayTarget()
+            ?: getString(R.string.ssh_notification_title)
+        val notification = buildNotification(hostLabel)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun buildNotification(hostLabel: String): Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, TerminalActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+        val disconnectIntent = PendingIntent.getService(
+            this,
+            0,
+            Intent(this, SshConnectionService::class.java).setAction(ACTION_DISCONNECT),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_terminal)
+            .setContentTitle(getString(R.string.ssh_notification_title))
+            .setContentText(hostLabel)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setContentIntent(contentIntent)
+            .addAction(R.drawable.ic_link_off, getString(R.string.ssh_notification_action_disconnect), disconnectIntent)
+            .build()
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) {
+            return
+        }
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.ssh_notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        manager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "ssh_connection"
+        private const val NOTIFICATION_ID = 1001
+        private const val ACTION_DISCONNECT = "net.hlan.sushi.action.DISCONNECT_SSH"
+
+        fun start(context: Context) {
+            val intent = Intent(context, SshConnectionService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, SshConnectionService::class.java))
+        }
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/SshConnectionService.kt
+++ b/app/src/main/java/net/hlan/sushi/SshConnectionService.kt
@@ -37,15 +37,22 @@ class SshConnectionService : Service() {
         val hostLabel = TerminalSessionHolder.getActiveConfig()?.displayTarget()
             ?: getString(R.string.ssh_notification_title)
         val notification = buildNotification(hostLabel)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            ServiceCompat.startForeground(
-                this,
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        }.onFailure {
+            // The OS can refuse a foreground-service promotion (e.g. background start
+            // restrictions); the SSH session itself is unaffected, only the background
+            // keep-alive, so just give up on the notification rather than crash.
+            stopSelf()
         }
         return START_NOT_STICKY
     }

--- a/app/src/main/java/net/hlan/sushi/SushiApplication.kt
+++ b/app/src/main/java/net/hlan/sushi/SushiApplication.kt
@@ -7,5 +7,15 @@ class SushiApplication : Application() {
         super.onCreate()
         AppThemeSettings(this).applyThemeMode()
         SshSettings(this).seedLocalHostIfMissing()
+
+        TerminalSessionHolder.addListener(object : TerminalSessionHolder.ConnectionListener {
+            override fun onConnected() {
+                SshConnectionService.start(this@SushiApplication)
+            }
+
+            override fun onDisconnected() {
+                SshConnectionService.stop(this@SushiApplication)
+            }
+        })
     }
 }

--- a/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
@@ -1,16 +1,21 @@
 package net.hlan.sushi
 
+import android.Manifest
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -41,6 +46,8 @@ class TerminalActivity : AppCompatActivity() {
     private val connectionMonitorRunnable = Runnable {
         monitorConnection()
     }
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op either way */ }
 
     private fun monitorConnection() {
         val client = sshClient
@@ -102,9 +109,28 @@ class TerminalActivity : AppCompatActivity() {
 
         updateUi()
         connectionMonitorHandler.postDelayed(connectionMonitorRunnable, CONNECTION_MONITOR_INTERVAL_MS)
+        requestNotificationPermissionIfNeeded()
 
         if (intent?.getBooleanExtra(EXTRA_AUTO_CONNECT, false) == true) {
             connectTerminal()
+        }
+    }
+
+    /**
+     * Lets the "session active" notification actually show on Android 13+, where posting it
+     * requires a runtime grant. The foreground service that keeps the SSH session alive in the
+     * background still runs without it — this only affects whether the user sees it.
+     */
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return
+        }
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 

--- a/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalActivity.kt
@@ -282,6 +282,7 @@ class TerminalActivity : AppCompatActivity() {
         saveTerminalLog()
         sshClient?.disconnect()
         sshClient = null
+        TerminalSessionHolder.clearActiveConnection()
         didLoseConnection = true
         binding.terminalOutputText.appendLog(getString(R.string.terminal_connection_lost_log))
         Toast.makeText(this, getString(R.string.terminal_connection_lost_toast), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/net/hlan/sushi/TerminalView.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalView.kt
@@ -35,6 +35,8 @@ class TerminalView @JvmOverloads constructor(
         private const val MAX_LINES = 500
         private const val MAX_CHARS = 200_000
         private val ESCAPE_PATTERN = Pattern.compile("\u001B\\[[0-9;?]*[a-ln-zA-LN-Z]")
+        // OSC (window title, etc.): ESC ] ... terminated by BEL or ESC \
+        private val OSC_PATTERN = Pattern.compile("\u001B\\][^\u0007\u001B]*(?:\u0007|\u001B\\\\)")
         private val SGR_PATTERN = Pattern.compile("\u001B\\[([0-9;]*)m")
     }
 
@@ -137,8 +139,7 @@ class TerminalView @JvmOverloads constructor(
     fun appendLog(text: String) {
         // Prevent DoS from extremely large input strings by truncating
         val safeText = if (text.length > 50000) text.substring(text.length - 50000) else text
-        val normalizedText = normalizeLineEndings(safeText)
-        rawTextBuffer.append(normalizedText)
+        appendWithCarriageReturnHandling(safeText)
         val dropped = trimBuffer()
         updateText(dropped)
     }
@@ -228,31 +229,43 @@ class TerminalView @JvmOverloads constructor(
         return 0
     }
 
-    private fun normalizeLineEndings(input: String): String {
-        if (input.isEmpty()) {
-            return input
-        }
-
-        val out = StringBuilder(input.length)
+    /**
+     * A bare `\r` (progress bars, spinners, and full-screen redraws) means "return to the
+     * start of the current line", so what follows should overwrite it rather than append
+     * after it. `\r\n` is just a line terminator and must not erase the line it ends.
+     * Since the `\r` and the character that disambiguates it can arrive in separate
+     * [appendLog] chunks, [pendingCarriageReturn] carries that decision across calls.
+     */
+    private fun appendWithCarriageReturnHandling(input: String) {
         for (ch in input) {
+            if (pendingCarriageReturn) {
+                pendingCarriageReturn = false
+                if (ch == '\n') {
+                    rawTextBuffer.append('\n')
+                    continue
+                }
+                eraseCurrentLine()
+            }
+
             when (ch) {
                 '\r' -> pendingCarriageReturn = true
-                '\n' -> {
-                    out.append('\n')
-                    pendingCarriageReturn = false
-                }
-                else -> {
-                    pendingCarriageReturn = false
-                    out.append(ch)
-                }
+                '\n' -> rawTextBuffer.append('\n')
+                else -> rawTextBuffer.append(ch)
             }
         }
-        return out.toString()
+    }
+
+    private fun eraseCurrentLine() {
+        val lineStart = rawTextBuffer.lastIndexOf("\n") + 1
+        rawTextBuffer.setLength(lineStart)
     }
 
     private fun parseAnsi(rawText: String): CharSequence {
+        // Strip OSC sequences (e.g. window-title changes) before the CSI ones below —
+        // otherwise their payload (e.g. "0;some title") leaks into the rendered text.
+        val withoutOsc = OSC_PATTERN.matcher(rawText).replaceAll("")
         // Strip out non-color ANSI escape sequences (e.g. cursor movements)
-        val text = ESCAPE_PATTERN.matcher(rawText).replaceAll("")
+        val text = ESCAPE_PATTERN.matcher(withoutOsc).replaceAll("")
 
         val builder = SpannableStringBuilder()
         val matcher = SGR_PATTERN.matcher(text)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,9 @@
     <string name="terminal_connect_failed_log">[Terminal] Connection failed: %1$s</string>
     <string name="terminal_connection_lost_log">[Terminal] Connection lost unexpectedly.</string>
     <string name="terminal_connection_lost_toast">Connection lost. You can reconnect now.</string>
+    <string name="ssh_notification_channel_name">Active session</string>
+    <string name="ssh_notification_title">Session active</string>
+    <string name="ssh_notification_action_disconnect">Disconnect</string>
     <string name="action_show_tools">Show tools</string>
     <string name="action_hide_tools">Hide tools</string>
     <string name="ssh_section_title">SSH connection</string>


### PR DESCRIPTION
The session lived entirely in process memory with no foreground
service, so Android froze or killed the process shortly after Sushi
left the foreground, dropping the connection mid-session.

Add SshConnectionService, a connectedDevice-type foreground service
started/stopped centrally via the existing TerminalSessionHolder
listener hooks whenever a session connects or disconnects. It shows a
persistent "Session active" notification with a one-tap disconnect
action and requests POST_NOTIFICATIONS on Android 13+ so it's visible.