### PR TITLE
fix(terminal): filter OSC sequences, CR overwrite, backspace echo

### DIFF
--- a/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeTest.kt
@@ -118,4 +118,11 @@ class TerminalViewEscapeTest {
         view.appendLog("\b\b\bx\n")
         assertEquals("line1\nx\n", view.getRawText())
     }
+
+    @Test
+    fun backspaceDoesNotCorruptAnsiEscapeSequences() {
+        view.appendLog("\u001B[31mred\u001B[0m")
+        view.appendLog("\b \b") // erase the last printable char, not the escape terminator
+        assertEquals("\u001B[31mre\u001B[0m", view.getRawText())
+    }
 }

--- a/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeTest.kt
+++ b/app/src/androidTest/java/net/hlan/sushi/TerminalViewEscapeTest.kt
@@ -1,0 +1,121 @@
+package net.hlan.sushi
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for OSC filtering (#126) and carriage-return overwrite (#127).
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalViewEscapeTest {
+
+    private lateinit var view: TerminalView
+
+    @Before
+    fun setUp() {
+        view = TerminalView(InstrumentationRegistry.getInstrumentation().targetContext)
+    }
+
+    // --- OSC sequences (#126) ---
+
+    @Test
+    fun oscTitleSequenceBelTerminatedIsFiltered() {
+        view.appendLog("\u001B]0;larry@edge: ~\u0007hello\n")
+        assertEquals("hello\n", view.getRawText())
+    }
+
+    @Test
+    fun oscSequenceStTerminatedIsFiltered() {
+        view.appendLog("\u001B]2;title\u001B\\ok\n")
+        assertEquals("ok\n", view.getRawText())
+    }
+
+    @Test
+    fun oscSplitAcrossChunksIsFiltered() {
+        view.appendLog("\u001B]0;lar")
+        view.appendLog("ry@edge\u0007hello\n")
+        assertEquals("hello\n", view.getRawText())
+    }
+
+    @Test
+    fun escSplitFromBracketAcrossChunksIsFiltered() {
+        view.appendLog("\u001B")
+        view.appendLog("]0;title\u0007hello\n")
+        assertEquals("hello\n", view.getRawText())
+    }
+
+    @Test
+    fun unterminatedOscDoesNotSwallowForever() {
+        view.appendLog("\u001B]0;" + "x".repeat(3000))
+        view.appendLog("visible\n")
+        assertEquals("visible\n", view.getRawText().takeLast(8))
+    }
+
+    @Test
+    fun csiColorSequencesStillRender() {
+        view.appendLog("\u001B[31mred\u001B[0m\n")
+        assertEquals("red\n", view.text.toString())
+    }
+
+    // --- Carriage-return overwrite (#127) ---
+
+    @Test
+    fun carriageReturnRestartsCurrentLine() {
+        view.appendLog("AAAA\rBB\n")
+        assertEquals("BB\n", view.getRawText())
+    }
+
+    @Test
+    fun promptRedrawAfterSigwinchDoesNotDuplicate() {
+        view.appendLog("larry@edge:~ $ ")
+        // bash redraws the prompt on SIGWINCH: CR + erase-line + prompt
+        view.appendLog("\r\u001B[Klarry@edge:~ $ ")
+        assertEquals("larry@edge:~ $ ", view.text.toString())
+    }
+
+    @Test
+    fun progressBarRepaintsCollapseToLastState() {
+        view.appendLog("10%\r20%\r30%\rdone\n")
+        assertEquals("done\n", view.getRawText())
+    }
+
+    @Test
+    fun carriageReturnSplitAcrossChunks() {
+        view.appendLog("AAAA\r")
+        view.appendLog("BB\n")
+        assertEquals("BB\n", view.getRawText())
+    }
+
+    @Test
+    fun crlfIsStillASingleNewline() {
+        view.appendLog("line1\r\nline2\n")
+        assertEquals("line1\nline2\n", view.getRawText())
+    }
+
+    @Test
+    fun carriageReturnOnFirstLineWithoutNewline() {
+        view.appendLog("abc\rxy\n")
+        assertEquals("xy\n", view.getRawText())
+    }
+
+    // --- Backspace echo ---
+
+    @Test
+    fun backspaceEchoErasesCharacter() {
+        view.appendLog("li")
+        view.appendLog("\b \b") // remote echo of one backspace keypress
+        view.appendLog("s\n")
+        assertEquals("ls\n", view.getRawText())
+    }
+
+    @Test
+    fun backspaceDoesNotCrossLineBoundary() {
+        view.appendLog("line1\n")
+        view.appendLog("\b\b\bx\n")
+        assertEquals("line1\nx\n", view.getRawText())
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/TerminalView.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalView.kt
@@ -290,11 +290,7 @@ class TerminalView @JvmOverloads constructor(
             }
             '\b' -> {
                 // Remote echoes "\b \b" to erase a character; apply the erase locally.
-                // Never cross a line boundary.
-                val len = rawTextBuffer.length
-                if (len > 0 && rawTextBuffer[len - 1] != '\n') {
-                    rawTextBuffer.setLength(len - 1)
-                }
+                eraseLastPrintableChar()
             }
             else -> {
                 if (pendingCarriageReturn) {
@@ -304,6 +300,34 @@ class TerminalView @JvmOverloads constructor(
                 }
                 rawTextBuffer.append(ch)
             }
+        }
+    }
+
+    /**
+     * Erases the last printable character on the current line, never crossing a `\n`.
+     * Trailing CSI/SGR escape sequences (`ESC [ [0-9;?]* letter`, e.g. a `ESC[0m`
+     * color reset) are skipped rather than truncated, so a backspace can't corrupt a
+     * still-open escape sequence into raw codes. OSC is already stripped upstream in
+     * [processChar], so only CSI sequences and printable text reach the buffer.
+     */
+    private fun eraseLastPrintableChar() {
+        var i = rawTextBuffer.length - 1
+        while (i >= 0) {
+            val c = rawTextBuffer[i]
+            if (c == '\n') return
+            if (c.isLetter()) {
+                // Possible CSI/SGR terminator — walk back over its parameter bytes.
+                var j = i - 1
+                while (j >= 0 && (rawTextBuffer[j].isDigit() || rawTextBuffer[j] == ';' || rawTextBuffer[j] == '?')) {
+                    j--
+                }
+                if (j >= 1 && rawTextBuffer[j] == '[' && rawTextBuffer[j - 1] == '\u001B') {
+                    i = j - 2
+                    continue
+                }
+            }
+            rawTextBuffer.deleteCharAt(i)
+            return
         }
     }
 

--- a/app/src/main/java/net/hlan/sushi/TerminalView.kt
+++ b/app/src/main/java/net/hlan/sushi/TerminalView.kt
@@ -26,14 +26,22 @@ class TerminalView @JvmOverloads constructor(
     private var currentBgColor: Int? = null
     private val rawTextBuffer = StringBuilder()
     private var pendingCarriageReturn = false
+    private var oscState = OscState.NONE
+    private var oscLength = 0
     var onInputText: ((String) -> Unit)? = null
     var renderAnsi: Boolean = true
+
+    // OSC sequences (ESC ] ... BEL/ST) can be split across network chunks,
+    // so the filter state must persist between appendLog calls.
+    private enum class OscState { NONE, ESC_SEEN, IN_OSC, IN_OSC_ESC_SEEN }
 
     var onSizeChangedListener: ((col: Int, row: Int, wp: Int, hp: Int) -> Unit)? = null
 
     companion object {
         private const val MAX_LINES = 500
         private const val MAX_CHARS = 200_000
+        // Unterminated OSC guard: a missing BEL/ST must not swallow output forever.
+        private const val MAX_OSC_LENGTH = 2048
         private val ESCAPE_PATTERN = Pattern.compile("\u001B\\[[0-9;?]*[a-ln-zA-LN-Z]")
         private val SGR_PATTERN = Pattern.compile("\u001B\\[([0-9;]*)m")
     }
@@ -137,8 +145,9 @@ class TerminalView @JvmOverloads constructor(
     fun appendLog(text: String) {
         // Prevent DoS from extremely large input strings by truncating
         val safeText = if (text.length > 50000) text.substring(text.length - 50000) else text
-        val normalizedText = normalizeLineEndings(safeText)
-        rawTextBuffer.append(normalizedText)
+        for (ch in safeText) {
+            processChar(ch)
+        }
         val dropped = trimBuffer()
         updateText(dropped)
     }
@@ -228,26 +237,74 @@ class TerminalView @JvmOverloads constructor(
         return 0
     }
 
-    private fun normalizeLineEndings(input: String): String {
-        if (input.isEmpty()) {
-            return input
-        }
-
-        val out = StringBuilder(input.length)
-        for (ch in input) {
-            when (ch) {
-                '\r' -> pendingCarriageReturn = true
-                '\n' -> {
-                    out.append('\n')
-                    pendingCarriageReturn = false
+    /**
+     * Filters OSC sequences (ESC ] ... BEL/ST — e.g. xterm window titles) out of the
+     * stream before buffering. CSI sequences pass through untouched; parseAnsi strips
+     * or renders them later.
+     */
+    private fun processChar(ch: Char) {
+        when (oscState) {
+            OscState.ESC_SEEN -> {
+                oscState = OscState.NONE
+                if (ch == ']') {
+                    oscState = OscState.IN_OSC
+                    oscLength = 0
+                    return
                 }
-                else -> {
-                    pendingCarriageReturn = false
-                    out.append(ch)
+                // Not an OSC — emit the withheld ESC, then handle ch normally.
+                appendChar('\u001B')
+            }
+            OscState.IN_OSC -> {
+                oscLength++
+                when {
+                    ch == '\u0007' -> oscState = OscState.NONE
+                    ch == '\u001B' -> oscState = OscState.IN_OSC_ESC_SEEN
+                    oscLength > MAX_OSC_LENGTH -> oscState = OscState.NONE
+                }
+                return
+            }
+            OscState.IN_OSC_ESC_SEEN -> {
+                oscState = if (ch == '\\') OscState.NONE else OscState.IN_OSC
+                return
+            }
+            OscState.NONE -> Unit
+        }
+        if (ch == '\u001B') {
+            oscState = OscState.ESC_SEEN
+            return
+        }
+        appendChar(ch)
+    }
+
+    /**
+     * Appends with carriage-return overwrite semantics: a `\r` not followed by `\n`
+     * restarts the current line, so shell prompt redraws (SIGWINCH) and progress bars
+     * (wget, apt) repaint one line instead of appending duplicates.
+     */
+    private fun appendChar(ch: Char) {
+        when (ch) {
+            '\r' -> pendingCarriageReturn = true
+            '\n' -> {
+                rawTextBuffer.append('\n')
+                pendingCarriageReturn = false
+            }
+            '\b' -> {
+                // Remote echoes "\b \b" to erase a character; apply the erase locally.
+                // Never cross a line boundary.
+                val len = rawTextBuffer.length
+                if (len > 0 && rawTextBuffer[len - 1] != '\n') {
+                    rawTextBuffer.setLength(len - 1)
                 }
             }
+            else -> {
+                if (pendingCarriageReturn) {
+                    val lastNewline = rawTextBuffer.lastIndexOf("\n")
+                    rawTextBuffer.setLength(if (lastNewline >= 0) lastNewline + 1 else 0)
+                    pendingCarriageReturn = false
+                }
+                rawTextBuffer.append(ch)
+            }
         }
-        return out.toString()
     }
 
     private fun parseAnsi(rawText: String): CharSequence {


### PR DESCRIPTION
## Summary

Fixes three TerminalView rendering gaps reported while testing v0.7.3 on the Pixel (Android 17):

1. **OSC title leak (#126)** — `ESC ]0;...BEL` window-title sequences rendered as literal `]0;...` before every prompt. Now filtered with a chunk-safe state machine (sequences split across network reads are handled; unterminated sequences are capped at 2 KB).
2. **Duplicate prompt on rotation (#127)** — `\r` was dropped, so SIGWINCH prompt redraws and `\r`-repainting progress bars (wget/apt) appended new lines. A CR not followed by LF now restarts the current line.
3. **Backspace echo** — the remote's `\b \b` erase echo was not applied, leaving typed-then-erased characters visible (`lils` when typing `li<BS>s`). `\b` now erases the last character on the current line, never crossing a line boundary.

## Testing

- New `TerminalViewEscapeTest` (14 cases: OSC BEL/ST termination, chunk splits, DoS guard, CSI color regression, CR overwrite variants, CRLF, backspace) — **passes on Nokia G42 5G (Android 15)**
- `TerminalViewSelectionTest` still green (buffer restructure touched shared paths)
- Emulator Tests (API 37) will exercise the same suite on Android 17 via this PR

Fixes #126, fixes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENspciP9BCM4PNvkCBXhfw