### PR TITLE
chore: release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ The format is based on Keep a Changelog and follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-07-26
+
 ### Fixed
 - Fixed SSH sessions dropping when Sushi is backgrounded: a foreground service (`SshConnectionService`) now keeps the process alive while a terminal session is connected, with a persistent "Session active" notification offering a one-tap disconnect.
 - Fixed `TerminalView` leaking raw OSC escape-sequence payloads (e.g. window-title text like `0;some title`) into the rendered terminal output; OSC sequences are now stripped like the existing CSI ones.
 - Fixed bare `\r` (progress bars, spinners, in-place redraws) being silently dropped instead of overwriting the current line, including when the `\r` and the following character arrive in separate read chunks.
+- Fixed backspace echo (`\b \b`) not erasing typed-then-deleted characters in the terminal, and made the erase skip over trailing ANSI escape sequences so it never corrupts an open color/CSI sequence.
+
+### Changed
+- Upgraded com.github.mwiede:jsch from 2.28.3 to 2.28.4.
+- Upgraded org.bouncycastle:bcprov-jdk18on from 1.84 to 1.85.
+- Upgraded Android Gradle Plugin (com.android.application) from 9.2.1 to 9.3.0.
+- Upgraded com.google.http-client:google-http-client-android from 2.1.1 to 2.2.0.
+- Upgraded com.google.mlkit:genai-prompt from 1.0.0-beta2 to 1.0.0-beta3.
 
 ## [0.7.3] - 2026-07-08
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "net.hlan.sushi"
         minSdk = 26
         targetSdk = 36
-        versionCode = versionCodeOverride ?: 19
-        versionName = versionNameOverride ?: "0.7.3"
+        versionCode = versionCodeOverride ?: 20
+        versionName = versionNameOverride ?: "0.7.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

Cuts release **0.7.4** (versionCode 20). Finalizes the CHANGELOG `[Unreleased]` section as `[0.7.4] - 2026-07-26` and bumps `versionName` 0.7.3 → 0.7.4 / `versionCode` 19 → 20 in `app/build.gradle.kts`.

This gathers everything merged to `main` since 0.7.3:
- **Fixed:** SSH sessions surviving app backgrounding (`SshConnectionService` foreground service), `TerminalView` OSC leak (#126), bare-`\r` overwrite / duplicate-prompt-on-rotation (#127), and backspace echo (`\b \b`) incl. ANSI-safe erase.
- **Changed (dependency upgrades):** jsch 2.28.3→2.28.4, bouncycastle 1.84→1.85, Android Gradle Plugin 9.2.1→9.3.0, google-http-client 2.1.1→2.2.0, mlkit genai-prompt beta2→beta3.

> Note on version code: the release workflow computes the Play-store `versionCode` from the tag (0.7.4 → 70401) at build time; the `build.gradle.kts` bump to 20 keeps local/debug builds and history consistent, matching prior release-cut commits.

## Changes

- `app/build.gradle.kts`: `versionName` → `0.7.4`, `versionCode` → `20`.
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.7.4]`, add the backspace-echo fix entry and the dependency-upgrade `Changed` section, leave a fresh empty `[Unreleased]` header.

## UI / UX changes

- [ ] Yes — Figma frame linked below
- [x] No — purely logic/backend change (version + changelog only)

**Figma frame:** N/A

## Test plan

- [ ] Tested on device / emulator
- [x] No regressions in existing flows

No code changes — version metadata and changelog only. The shipped fixes/deps were each validated by CI on their own PRs, and the combined `main` build (Android CI on `1a236f64`) is green after the dependency merges. Tagging `v0.7.4` after merge runs the full release build.

## Checklist

- [x] User-visible strings added to `strings.xml` — N/A
- [x] No hardcoded secrets
- [x] ProGuard rules updated if new reflection-loaded classes added — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2akuCCN8j1bAhXVnBmsXv)_