### PR TITLE
feat(feedback): send in-app feedback as GitHub issues, auto-assign Copilot

### DIFF
--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -1,0 +1,70 @@
+name: Assign Copilot to app feedback
+
+# Issues created from the in-app feedback feature carry the `from-app` label.
+# This workflow assigns the Copilot coding agent to them so a fix PR gets
+# drafted without anyone needing to sit at a computer.
+#
+# Assigning the Copilot coding agent requires a token that is allowed to do so;
+# the default GITHUB_TOKEN usually is not. Set the COPILOT_ASSIGN_TOKEN secret
+# (fine-grained PAT, Issues: Read+Write on this repo) — the workflow falls back
+# to GITHUB_TOKEN and fails visibly if neither works, in which case the issue
+# can still be assigned manually from the GitHub mobile app.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    if: github.event.label.name == 'from-app'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign Copilot coding agent
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          BOT_ID=$(gh api graphql -f query='
+            query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) {
+                suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+                  nodes { login ... on Bot { id } }
+                }
+              }
+            }' -f owner="$OWNER" -f name="$NAME" \
+            --jq '.data.repository.suggestedActors.nodes[] | select(.login == "copilot-swe-agent") | .id')
+
+          if [ -z "$BOT_ID" ]; then
+            echo "::error::Copilot coding agent is not assignable in this repository. Assign it manually from the GitHub app."
+            exit 1
+          fi
+
+          ISSUE_ID=$(gh api graphql -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                issue(number: $number) { id }
+              }
+            }' -f owner="$OWNER" -f name="$NAME" -F number="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.id')
+
+          gh api graphql -f query='
+            mutation($assignableId: ID!, $actorIds: [ID!]!) {
+              replaceActorsForAssignable(input: {assignableId: $assignableId, actorIds: $actorIds}) {
+                assignable { ... on Issue { number } }
+              }
+            }' -f assignableId="$ISSUE_ID" -f actorIds="[\"$BOT_ID\"]" 2>/dev/null || \
+          gh api graphql -f query='
+            mutation($assignableId: ID!, $actorIds: [ID!]!) {
+              replaceActorsForAssignable(input: {assignableId: $assignableId, actorIds: $actorIds}) {
+                assignable { ... on Issue { number } }
+              }
+            }' -f assignableId="$ISSUE_ID" -F "actorIds[]=$BOT_ID"
+
+          echo "Copilot assigned to issue #$ISSUE_NUMBER"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+# Daily sweep that merges dependabot PRs whose checks are all green, so routine
+# dependency updates don't sit waiting for a human. Major version bumps are
+# skipped — those need a human look.
+#
+# Merges one PR per run on purpose: dependabot rebases its remaining PRs after
+# each merge, which restarts their checks. The next scheduled run (or a manual
+# dispatch) picks up the next green PR.
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge first green non-major dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "$REPO" --author "app/dependabot" --state open \
+            --json number,title --jq '.[] | "\(.number)\t\(.title)"' |
+          while IFS=$'\t' read -r num title; do
+            from=$(sed -nE 's/.* from ([0-9]+)(\.[0-9A-Za-z.-]+)? to .*/\1/p' <<<"$title")
+            to=$(sed -nE 's/.* to ([0-9]+)(\.[0-9A-Za-z.-]+)?$/\1/p' <<<"$title")
+            if [ -n "$from" ] && [ -n "$to" ] && [ "$from" != "$to" ]; then
+              echo "#$num SKIP (major bump): $title"
+              continue
+            fi
+            if gh pr checks "$num" --repo "$REPO" >/dev/null 2>&1; then
+              echo "#$num MERGE: $title"
+              gh pr merge "$num" --repo "$REPO" --merge
+              break
+            else
+              echo "#$num skip (checks not green yet): $title"
+            fi
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ google-services.json
 # OS files
 .DS_Store
 Thumbs.db
+.tmp/

--- a/app/src/main/java/net/hlan/sushi/FeedbackSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/FeedbackSettings.kt
@@ -1,0 +1,19 @@
+package net.hlan.sushi
+
+import android.content.Context
+
+class FeedbackSettings(context: Context) {
+    private val prefs = SecurePrefs.get(context)
+
+    fun getGitHubToken(): String = prefs.getString(KEY_GITHUB_TOKEN, "") ?: ""
+
+    fun setGitHubToken(token: String) {
+        prefs.edit().putString(KEY_GITHUB_TOKEN, token).apply()
+    }
+
+    fun isConfigured(): Boolean = getGitHubToken().isNotBlank()
+
+    companion object {
+        private const val KEY_GITHUB_TOKEN = "feedback_github_token"
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/GitHubIssueClient.kt
+++ b/app/src/main/java/net/hlan/sushi/GitHubIssueClient.kt
@@ -1,0 +1,91 @@
+package net.hlan.sushi
+
+import android.content.Context
+import android.os.Build
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * Creates GitHub issues from in-app feedback. Uses a fine-grained personal
+ * access token (Issues: Read+Write on the app repo only) stored in SecurePrefs.
+ */
+class GitHubIssueClient(
+    private val context: Context,
+    private val settings: FeedbackSettings
+) {
+
+    fun createIssue(feedback: String, includeDeviceInfo: Boolean): FeedbackResult {
+        val token = settings.getGitHubToken().trim()
+        if (token.isEmpty()) {
+            return FeedbackResult(false, context.getString(R.string.feedback_missing_token))
+        }
+
+        val title = feedback.lineSequence().first().take(TITLE_MAX_LENGTH).ifBlank {
+            context.getString(R.string.feedback_default_title)
+        }
+        val body = buildString {
+            append(feedback)
+            if (includeDeviceInfo) {
+                val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                append("\n\n---\n")
+                append("- App: ${packageInfo.versionName} (${packageInfo.longVersionCode})\n")
+                append("- Device: ${Build.MANUFACTURER} ${Build.MODEL}\n")
+                append("- Android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+            }
+        }
+
+        val requestBody = JSONObject().apply {
+            put("title", title)
+            put("body", body)
+            put("labels", JSONArray().put(LABEL))
+        }
+
+        val connection = URI(ISSUES_URL).toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Authorization", "Bearer $token")
+        connection.setRequestProperty("Accept", "application/vnd.github+json")
+        connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.doOutput = true
+
+        return try {
+            connection.outputStream.use { outputStream ->
+                outputStream.write(requestBody.toString().toByteArray(Charsets.UTF_8))
+            }
+
+            if (connection.responseCode == HttpURLConnection.HTTP_CREATED) {
+                val response = BufferedReader(InputStreamReader(connection.inputStream)).use { it.readText() }
+                val issueUrl = JSONObject(response).optString("html_url")
+                FeedbackResult(true, issueUrl)
+            } else {
+                val error = connection.errorStream?.let { stream ->
+                    BufferedReader(InputStreamReader(stream)).use { it.readText() }
+                }.orEmpty()
+                val message = runCatching { JSONObject(error).optString("message") }
+                    .getOrNull()
+                    .orEmpty()
+                    .ifBlank { context.getString(R.string.feedback_send_failed) }
+                FeedbackResult(false, "${connection.responseCode}: $message")
+            }
+        } catch (ex: Exception) {
+            FeedbackResult(false, ex.message ?: context.getString(R.string.feedback_send_failed))
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    companion object {
+        private const val ISSUES_URL = "https://api.github.com/repos/hlan-net/sushi-ssh-client/issues"
+        private const val LABEL = "from-app"
+        private const val TITLE_MAX_LENGTH = 80
+    }
+}
+
+data class FeedbackResult(
+    val success: Boolean,
+    val message: String
+)

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -19,12 +19,14 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.mlkit.genai.common.FeatureStatus
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.hlan.sushi.databinding.ActivitySettingsBinding
+import net.hlan.sushi.databinding.DialogFeedbackBinding
 import net.hlan.sushi.databinding.PageSettingsDriveBinding
 import net.hlan.sushi.databinding.PageSettingsGeminiBinding
 import net.hlan.sushi.databinding.PageSettingsGeneralBinding
@@ -39,6 +41,8 @@ class SettingsActivity : AppCompatActivity() {
     private val geminiClient by lazy { GeminiClient(this, settings, driveAuthManager) }
     private val nanoClient by lazy { GeminiNanoClient(this) }
     private val sshSettings by lazy { SshSettings(this) }
+    private val feedbackSettings by lazy { FeedbackSettings(this) }
+    private val gitHubIssueClient by lazy { GitHubIssueClient(this, feedbackSettings) }
     private var generalPageBinding: PageSettingsGeneralBinding? = null
     private var sshPageBinding: PageSettingsSshBinding? = null
     private var geminiPageBinding: PageSettingsGeminiBinding? = null
@@ -190,6 +194,50 @@ class SettingsActivity : AppCompatActivity() {
 
         pageBinding.managePhrasesButton.setOnClickListener {
             startActivity(Intent(this, PhrasesActivity::class.java))
+        }
+
+        pageBinding.githubTokenInput.setText(feedbackSettings.getGitHubToken())
+        pageBinding.githubTokenInput.doAfterTextChanged { editable ->
+            feedbackSettings.setGitHubToken(editable?.toString().orEmpty().trim())
+        }
+
+        pageBinding.sendFeedbackButton.setOnClickListener {
+            showFeedbackDialog()
+        }
+    }
+
+    private fun showFeedbackDialog() {
+        if (!feedbackSettings.isConfigured()) {
+            Toast.makeText(this, R.string.feedback_missing_token, Toast.LENGTH_LONG).show()
+            return
+        }
+        val dialogBinding = DialogFeedbackBinding.inflate(layoutInflater)
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.feedback_dialog_title)
+            .setView(dialogBinding.root)
+            .setPositiveButton(R.string.feedback_send) { _, _ ->
+                val text = dialogBinding.feedbackTextInput.text?.toString().orEmpty().trim()
+                if (text.isEmpty()) {
+                    Toast.makeText(this, R.string.feedback_missing_text, Toast.LENGTH_SHORT).show()
+                } else {
+                    sendFeedback(text, dialogBinding.includeDeviceInfoCheckbox.isChecked)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun sendFeedback(text: String, includeDeviceInfo: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val result = gitHubIssueClient.createIssue(text, includeDeviceInfo)
+            withContext(Dispatchers.Main) {
+                val message = if (result.success) {
+                    getString(R.string.feedback_sent, result.message)
+                } else {
+                    getString(R.string.feedback_send_failed) + ": " + result.message
+                }
+                Toast.makeText(this@SettingsActivity, message, Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/app/src/main/res/layout/dialog_feedback.xml
+++ b/app/src/main/res/layout/dialog_feedback.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="8dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/feedbackTextLayout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/feedback_text_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/feedbackTextInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top"
+            android:inputType="textMultiLine|textCapSentences"
+            android:minLines="4"
+            android:maxLines="8" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/includeDeviceInfoCheckbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:checked="true"
+        android:text="@string/feedback_include_device_info" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/page_settings_general.xml
+++ b/app/src/main/res/layout/page_settings_general.xml
@@ -131,5 +131,47 @@
             app:icon="@drawable/ic_format_quote"
             app:iconGravity="textStart" />
 
+        <TextView
+            android:id="@+id/feedbackSectionTitle"
+            style="@style/TextAppearance.Sushi.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/feedback_section_title" />
+
+        <TextView
+            android:id="@+id/feedbackSectionSubtitle"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/feedback_section_subtitle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/githubTokenLayout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="@string/feedback_token_label"
+            app:passwordToggleEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/githubTokenInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/sendFeedbackButton"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/feedback_send_button"
+            app:icon="@drawable/ic_send"
+            app:iconGravity="textStart" />
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -346,4 +346,18 @@
     <string name="conversation_init_failed">Keskustelun alustaminen epäonnistui: %1$s</string>
     <string name="conversation_connected_to">Yhdistetty: %1$s</string>
 
+    <!-- In-app feedback (GitHub issues) -->
+    <string name="feedback_section_title">Palaute</string>
+    <string name="feedback_section_subtitle">Lähetä palaute suoraan projektin GitHub-issueiksi. Vaatii fine-grained personal access tokenin, jolla on Issues-oikeus sovelluksen repoon.</string>
+    <string name="feedback_token_label">GitHub-token</string>
+    <string name="feedback_send_button">Lähetä palautetta</string>
+    <string name="feedback_dialog_title">Lähetä palautetta</string>
+    <string name="feedback_text_hint">Mitä tapahtui tai mikä voisi olla paremmin?</string>
+    <string name="feedback_include_device_info">Liitä sovellusversio ja laitetiedot</string>
+    <string name="feedback_send">Lähetä</string>
+    <string name="feedback_missing_token">Lisää ensin GitHub-token asetuksiin</string>
+    <string name="feedback_missing_text">Kirjoita ensin jotain</string>
+    <string name="feedback_default_title">Palaute sovelluksesta</string>
+    <string name="feedback_sent">Palaute lähetetty: %1$s</string>
+    <string name="feedback_send_failed">Palautteen lähetys epäonnistui</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -415,4 +415,18 @@
         <item quantity="one">%1$d turn</item>
         <item quantity="other">%1$d turns</item>
     </plurals>
+    <!-- In-app feedback (GitHub issues) -->
+    <string name="feedback_section_title">Feedback</string>
+    <string name="feedback_section_subtitle">Send feedback straight to the project\'s GitHub issues. Requires a fine-grained personal access token with Issues permission on the app repository.</string>
+    <string name="feedback_token_label">GitHub token</string>
+    <string name="feedback_send_button">Send feedback</string>
+    <string name="feedback_dialog_title">Send feedback</string>
+    <string name="feedback_text_hint">What happened, or what could be better?</string>
+    <string name="feedback_include_device_info">Include app version and device info</string>
+    <string name="feedback_send">Send</string>
+    <string name="feedback_missing_token">Add a GitHub token in Settings first</string>
+    <string name="feedback_missing_text">Write something first</string>
+    <string name="feedback_default_title">Feedback from app</string>
+    <string name="feedback_sent">Feedback sent: %1$s</string>
+    <string name="feedback_send_failed">Sending feedback failed</string>
 </resources>


### PR DESCRIPTION
## Summary

Problems noticed while using the app on the phone never become GitHub issues, because filing one requires a computer. This PR closes the loop so the whole cycle — report → issue → fix PR → review → merge — works from the phone.

**App:**
- New **Feedback** section in General settings: fine-grained GitHub PAT (Issues: Read+Write on this repo only, stored in `SecurePrefs`) + a **Send feedback** dialog
- Feedback becomes a GitHub issue labeled `from-app`, optionally with app version and device info
- `GitHubIssueClient` follows the existing `GeminiClient` pattern (raw `HttpURLConnection`, no SDK)

**Automation:**
- `assign-copilot.yml` — assigns the Copilot coding agent to `from-app` issues (needs `COPILOT_ASSIGN_TOKEN` secret if the default token can't assign; manual assignment from the GitHub app works as fallback)
- `dependabot-auto-merge.yml` — daily sweep merges green, non-major dependabot PRs so routine updates don't idle

## UX

Does this PR change the UI?
- [x] Yes — Figma design: https://www.figma.com/design/heP71zbxhc6Mtgpghp0dDw/Sushi?node-id=60-2

Proposal card on the Proposals page includes mockups of the settings section and the feedback dialog.

## Test plan

- [x] `compileDebugKotlin` + `processDebugResources` pass locally
- [ ] CI: build + API 37 emulator tests green (LayoutInflationTest covers the layout change)
- [ ] Manual: set token on device, send test feedback, verify issue + Copilot assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMDwyKJLRTEmfy1gvEW59z