### PR TITLE
feat(feedback): replace manual GitHub PAT with OAuth Device Flow

### DIFF
--- a/app/src/main/java/net/hlan/sushi/FeedbackSettings.kt
+++ b/app/src/main/java/net/hlan/sushi/FeedbackSettings.kt
@@ -11,9 +11,20 @@ class FeedbackSettings(context: Context) {
         prefs.edit().putString(KEY_GITHUB_TOKEN, token).apply()
     }
 
+    fun getGitHubUsername(): String = prefs.getString(KEY_GITHUB_USERNAME, "") ?: ""
+
+    fun setGitHubUsername(username: String) {
+        prefs.edit().putString(KEY_GITHUB_USERNAME, username).apply()
+    }
+
     fun isConfigured(): Boolean = getGitHubToken().isNotBlank()
+
+    fun clear() {
+        prefs.edit().remove(KEY_GITHUB_TOKEN).remove(KEY_GITHUB_USERNAME).apply()
+    }
 
     companion object {
         private const val KEY_GITHUB_TOKEN = "feedback_github_token"
+        private const val KEY_GITHUB_USERNAME = "feedback_github_username"
     }
 }

--- a/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
+++ b/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
@@ -1,0 +1,132 @@
+package net.hlan.sushi
+
+import kotlinx.coroutines.delay
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * GitHub OAuth Device Flow — no client secret needed, so the client ID is safe
+ * to embed in the app. The user approves sign-in on github.com/login/device
+ * from any browser instead of pasting a token on a phone keyboard.
+ */
+class GitHubAuthManager(private val settings: FeedbackSettings) {
+
+    data class DeviceCode(
+        val deviceCode: String,
+        val userCode: String,
+        val verificationUri: String,
+        val expiresIn: Int,
+        val interval: Int
+    )
+
+    sealed class DeviceFlowResult {
+        data class Success(val token: String, val username: String?) : DeviceFlowResult()
+        data class Failed(val message: String) : DeviceFlowResult()
+        object Denied : DeviceFlowResult()
+        object Expired : DeviceFlowResult()
+    }
+
+    /** Requests a device code. Must be called on a background thread. */
+    fun requestDeviceCode(): DeviceCode? {
+        val connection = post(DEVICE_CODE_URL, "client_id=$CLIENT_ID&scope=public_repo")
+        return try {
+            val response = JSONObject(readBody(connection))
+            DeviceCode(
+                deviceCode = response.getString("device_code"),
+                userCode = response.getString("user_code"),
+                verificationUri = response.getString("verification_uri"),
+                expiresIn = response.getInt("expires_in"),
+                interval = response.getInt("interval")
+            )
+        } catch (ex: Exception) {
+            null
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    /**
+     * Polls until the user approves, denies, or the code expires. Must be called
+     * on a background thread — suspends between polls with [delay].
+     */
+    suspend fun pollForToken(deviceCode: DeviceCode): DeviceFlowResult {
+        var interval = deviceCode.interval
+        val deadline = System.currentTimeMillis() + deviceCode.expiresIn * 1000L
+
+        while (System.currentTimeMillis() < deadline) {
+            delay(interval * 1000L)
+
+            val connection = post(
+                TOKEN_URL,
+                "client_id=$CLIENT_ID&device_code=${deviceCode.deviceCode}" +
+                    "&grant_type=urn:ietf:params:oauth:grant-type:device_code"
+            )
+            val response = try {
+                JSONObject(readBody(connection))
+            } catch (ex: Exception) {
+                return DeviceFlowResult.Failed(ex.message ?: "Network error")
+            } finally {
+                connection.disconnect()
+            }
+
+            when (response.optString("error")) {
+                "" -> {
+                    val token = response.optString("access_token")
+                    if (token.isNotBlank()) {
+                        settings.setGitHubToken(token)
+                        val username = fetchUsername(token)
+                        settings.setGitHubUsername(username.orEmpty())
+                        return DeviceFlowResult.Success(token, username)
+                    }
+                    return DeviceFlowResult.Failed("No access token in response")
+                }
+                "authorization_pending" -> continue
+                "slow_down" -> interval += SLOW_DOWN_INCREMENT_SECONDS
+                "access_denied" -> return DeviceFlowResult.Denied
+                "expired_token" -> return DeviceFlowResult.Expired
+                else -> return DeviceFlowResult.Failed(response.optString("error_description", "Unknown error"))
+            }
+        }
+        return DeviceFlowResult.Expired
+    }
+
+    private fun fetchUsername(token: String): String? {
+        val connection = URI(USER_URL).toURL().openConnection() as HttpURLConnection
+        connection.setRequestProperty("Authorization", "Bearer $token")
+        connection.setRequestProperty("Accept", "application/vnd.github+json")
+        return try {
+            JSONObject(readBody(connection)).optString("login").ifBlank { null }
+        } catch (ex: Exception) {
+            null
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun post(url: String, body: String): HttpURLConnection {
+        val connection = URI(url).toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+        connection.doOutput = true
+        OutputStreamWriter(connection.outputStream).use { it.write(body) }
+        return connection
+    }
+
+    private fun readBody(connection: HttpURLConnection): String {
+        val stream = if (connection.responseCode in 200..299) connection.inputStream else connection.errorStream
+        return BufferedReader(InputStreamReader(stream)).use { it.readText() }
+    }
+
+    companion object {
+        private const val CLIENT_ID = "Ov23li1omfB7ZAUAkgji"
+        private const val DEVICE_CODE_URL = "https://github.com/login/device/code"
+        private const val TOKEN_URL = "https://github.com/login/oauth/access_token"
+        private const val USER_URL = "https://api.github.com/user"
+        private const val SLOW_DOWN_INCREMENT_SECONDS = 5
+    }
+}

--- a/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
+++ b/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
@@ -32,20 +32,22 @@ class GitHubAuthManager(private val settings: FeedbackSettings) {
 
     /** Requests a device code. Must be called on a background thread. */
     fun requestDeviceCode(): DeviceCode? {
-        val connection = post(DEVICE_CODE_URL, "client_id=$CLIENT_ID&scope=public_repo")
         return try {
-            val response = JSONObject(readBody(connection))
-            DeviceCode(
-                deviceCode = response.getString("device_code"),
-                userCode = response.getString("user_code"),
-                verificationUri = response.getString("verification_uri"),
-                expiresIn = response.getInt("expires_in"),
-                interval = response.getInt("interval")
-            )
+            val connection = post(DEVICE_CODE_URL, "client_id=$CLIENT_ID&scope=public_repo")
+            try {
+                val response = JSONObject(readBody(connection))
+                DeviceCode(
+                    deviceCode = response.getString("device_code"),
+                    userCode = response.getString("user_code"),
+                    verificationUri = response.getString("verification_uri"),
+                    expiresIn = response.getInt("expires_in"),
+                    interval = response.getInt("interval")
+                )
+            } finally {
+                connection.disconnect()
+            }
         } catch (ex: Exception) {
             null
-        } finally {
-            connection.disconnect()
         }
     }
 
@@ -60,17 +62,19 @@ class GitHubAuthManager(private val settings: FeedbackSettings) {
         while (System.currentTimeMillis() < deadline) {
             delay(interval * 1000L)
 
-            val connection = post(
-                TOKEN_URL,
-                "client_id=$CLIENT_ID&device_code=${deviceCode.deviceCode}" +
-                    "&grant_type=urn:ietf:params:oauth:grant-type:device_code"
-            )
             val response = try {
-                JSONObject(readBody(connection))
+                val connection = post(
+                    TOKEN_URL,
+                    "client_id=$CLIENT_ID&device_code=${deviceCode.deviceCode}" +
+                        "&grant_type=urn:ietf:params:oauth:grant-type:device_code"
+                )
+                try {
+                    JSONObject(readBody(connection))
+                } finally {
+                    connection.disconnect()
+                }
             } catch (ex: Exception) {
                 return DeviceFlowResult.Failed(ex.message ?: "Network error")
-            } finally {
-                connection.disconnect()
             }
 
             when (response.optString("error")) {
@@ -98,25 +102,34 @@ class GitHubAuthManager(private val settings: FeedbackSettings) {
     }
 
     private fun fetchUsername(token: String): String? {
-        val connection = URI(USER_URL).toURL().openConnection() as HttpURLConnection
-        connection.setRequestProperty("Authorization", "Bearer $token")
-        connection.setRequestProperty("Accept", "application/vnd.github+json")
         return try {
-            JSONObject(readBody(connection)).optString("login").ifBlank { null }
+            val connection = newConnection(USER_URL)
+            connection.setRequestProperty("Authorization", "Bearer $token")
+            connection.setRequestProperty("Accept", "application/vnd.github+json")
+            try {
+                JSONObject(readBody(connection)).optString("login").ifBlank { null }
+            } finally {
+                connection.disconnect()
+            }
         } catch (ex: Exception) {
             null
-        } finally {
-            connection.disconnect()
         }
     }
 
     private fun post(url: String, body: String): HttpURLConnection {
-        val connection = URI(url).toURL().openConnection() as HttpURLConnection
+        val connection = newConnection(url)
         connection.requestMethod = "POST"
         connection.setRequestProperty("Accept", "application/json")
         connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
         connection.doOutput = true
         OutputStreamWriter(connection.outputStream).use { it.write(body) }
+        return connection
+    }
+
+    private fun newConnection(url: String): HttpURLConnection {
+        val connection = URI(url).toURL().openConnection() as HttpURLConnection
+        connection.connectTimeout = TIMEOUT_MS
+        connection.readTimeout = TIMEOUT_MS
         return connection
     }
 
@@ -131,5 +144,6 @@ class GitHubAuthManager(private val settings: FeedbackSettings) {
         private const val TOKEN_URL = "https://github.com/login/oauth/access_token"
         private const val USER_URL = "https://api.github.com/user"
         private const val SLOW_DOWN_INCREMENT_SECONDS = 5
+        private const val TIMEOUT_MS = 15_000
     }
 }

--- a/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
+++ b/app/src/main/java/net/hlan/sushi/GitHubAuthManager.kt
@@ -85,7 +85,10 @@ class GitHubAuthManager(private val settings: FeedbackSettings) {
                     return DeviceFlowResult.Failed("No access token in response")
                 }
                 "authorization_pending" -> continue
-                "slow_down" -> interval += SLOW_DOWN_INCREMENT_SECONDS
+                "slow_down" -> {
+                    interval += SLOW_DOWN_INCREMENT_SECONDS
+                    continue
+                }
                 "access_denied" -> return DeviceFlowResult.Denied
                 "expired_token" -> return DeviceFlowResult.Expired
                 else -> return DeviceFlowResult.Failed(response.optString("error_description", "Unknown error"))

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -27,6 +28,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.hlan.sushi.databinding.ActivitySettingsBinding
 import net.hlan.sushi.databinding.DialogFeedbackBinding
+import net.hlan.sushi.databinding.DialogGithubDeviceCodeBinding
 import net.hlan.sushi.databinding.PageSettingsDriveBinding
 import net.hlan.sushi.databinding.PageSettingsGeminiBinding
 import net.hlan.sushi.databinding.PageSettingsGeneralBinding
@@ -43,6 +45,7 @@ class SettingsActivity : AppCompatActivity() {
     private val sshSettings by lazy { SshSettings(this) }
     private val feedbackSettings by lazy { FeedbackSettings(this) }
     private val gitHubIssueClient by lazy { GitHubIssueClient(this, feedbackSettings) }
+    private val gitHubAuthManager by lazy { GitHubAuthManager(feedbackSettings) }
     private var generalPageBinding: PageSettingsGeneralBinding? = null
     private var sshPageBinding: PageSettingsSshBinding? = null
     private var geminiPageBinding: PageSettingsGeminiBinding? = null
@@ -196,13 +199,94 @@ class SettingsActivity : AppCompatActivity() {
             startActivity(Intent(this, PhrasesActivity::class.java))
         }
 
-        pageBinding.githubTokenInput.setText(feedbackSettings.getGitHubToken())
-        pageBinding.githubTokenInput.doAfterTextChanged { editable ->
-            feedbackSettings.setGitHubToken(editable?.toString().orEmpty().trim())
+        refreshGitHubAccountStatus(pageBinding)
+
+        pageBinding.githubSignInButton.setOnClickListener {
+            startGitHubDeviceFlow(pageBinding)
+        }
+
+        pageBinding.githubSignOutButton.setOnClickListener {
+            feedbackSettings.clear()
+            refreshGitHubAccountStatus(pageBinding)
         }
 
         pageBinding.sendFeedbackButton.setOnClickListener {
             showFeedbackDialog()
+        }
+    }
+
+    private fun refreshGitHubAccountStatus(pageBinding: PageSettingsGeneralBinding) {
+        val signedIn = feedbackSettings.isConfigured()
+        val username = feedbackSettings.getGitHubUsername()
+        pageBinding.githubAccountStatus.text = if (signedIn && username.isNotBlank()) {
+            getString(R.string.github_signed_in_as, username)
+        } else {
+            getString(R.string.github_not_signed_in)
+        }
+        pageBinding.githubSignInButton.visibility = if (signedIn) View.GONE else View.VISIBLE
+        pageBinding.githubSignOutButton.visibility = if (signedIn) View.VISIBLE else View.GONE
+    }
+
+    private fun startGitHubDeviceFlow(pageBinding: PageSettingsGeneralBinding) {
+        val dialogBinding = DialogGithubDeviceCodeBinding.inflate(layoutInflater)
+        var verificationUri: String? = null
+
+        dialogBinding.openGitHubButton.setOnClickListener {
+            verificationUri?.let { uri ->
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(uri)))
+            }
+        }
+
+        val dialog = MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.github_sign_in_button)
+            .setView(dialogBinding.root)
+            .setNegativeButton(android.R.string.cancel, null)
+            .setCancelable(false)
+            .show()
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val deviceCode = gitHubAuthManager.requestDeviceCode()
+            if (deviceCode == null) {
+                withContext(Dispatchers.Main) {
+                    dialogBinding.deviceCodeStatus.text =
+                        getString(R.string.github_device_flow_failed, "")
+                }
+                return@launch
+            }
+
+            withContext(Dispatchers.Main) {
+                verificationUri = deviceCode.verificationUri
+                dialogBinding.deviceCodeText.text = deviceCode.userCode
+            }
+
+            val result = gitHubAuthManager.pollForToken(deviceCode)
+
+            withContext(Dispatchers.Main) {
+                dialog.dismiss()
+                when (result) {
+                    is GitHubAuthManager.DeviceFlowResult.Success -> {
+                        refreshGitHubAccountStatus(pageBinding)
+                        Toast.makeText(
+                            this@SettingsActivity,
+                            getString(R.string.github_device_flow_success, result.username.orEmpty()),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                    is GitHubAuthManager.DeviceFlowResult.Failed -> {
+                        Toast.makeText(
+                            this@SettingsActivity,
+                            getString(R.string.github_device_flow_failed, result.message),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                    GitHubAuthManager.DeviceFlowResult.Denied -> {
+                        Toast.makeText(this@SettingsActivity, R.string.github_device_flow_denied, Toast.LENGTH_LONG).show()
+                    }
+                    GitHubAuthManager.DeviceFlowResult.Expired -> {
+                        Toast.makeText(this@SettingsActivity, R.string.github_device_flow_expired, Toast.LENGTH_LONG).show()
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/SettingsActivity.kt
@@ -24,6 +24,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.mlkit.genai.common.FeatureStatus
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.hlan.sushi.databinding.ActivitySettingsBinding
@@ -218,10 +219,10 @@ class SettingsActivity : AppCompatActivity() {
     private fun refreshGitHubAccountStatus(pageBinding: PageSettingsGeneralBinding) {
         val signedIn = feedbackSettings.isConfigured()
         val username = feedbackSettings.getGitHubUsername()
-        pageBinding.githubAccountStatus.text = if (signedIn && username.isNotBlank()) {
-            getString(R.string.github_signed_in_as, username)
-        } else {
-            getString(R.string.github_not_signed_in)
+        pageBinding.githubAccountStatus.text = when {
+            signedIn && username.isNotBlank() -> getString(R.string.github_signed_in_as, username)
+            signedIn -> getString(R.string.github_signed_in_generic)
+            else -> getString(R.string.github_not_signed_in)
         }
         pageBinding.githubSignInButton.visibility = if (signedIn) View.GONE else View.VISIBLE
         pageBinding.githubSignOutButton.visibility = if (signedIn) View.VISIBLE else View.GONE
@@ -237,14 +238,15 @@ class SettingsActivity : AppCompatActivity() {
             }
         }
 
+        var flowJob: Job? = null
         val dialog = MaterialAlertDialogBuilder(this)
             .setTitle(R.string.github_sign_in_button)
             .setView(dialogBinding.root)
-            .setNegativeButton(android.R.string.cancel, null)
+            .setNegativeButton(android.R.string.cancel) { _, _ -> flowJob?.cancel() }
             .setCancelable(false)
             .show()
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        flowJob = lifecycleScope.launch(Dispatchers.IO) {
             val deviceCode = gitHubAuthManager.requestDeviceCode()
             if (deviceCode == null) {
                 withContext(Dispatchers.Main) {

--- a/app/src/main/res/layout/dialog_github_device_code.xml
+++ b/app/src/main/res/layout/dialog_github_device_code.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/deviceCodeInstructions"
+        style="@style/TextAppearance.Sushi.Body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/github_device_flow_instructions" />
+
+    <TextView
+        android:id="@+id/deviceCodeText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:fontFamily="monospace"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:letterSpacing="0.15"
+        android:textIsSelectable="true"
+        tools:text="ABCD-1234" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/openGitHubButton"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="@string/github_device_flow_open_button"
+        app:icon="@drawable/ic_login"
+        app:iconGravity="textStart" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ProgressBar
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginEnd="10dp" />
+
+        <TextView
+            android:id="@+id/deviceCodeStatus"
+            style="@style/TextAppearance.Sushi.Caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/github_device_flow_waiting" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/page_settings_general.xml
+++ b/app/src/main/res/layout/page_settings_general.xml
@@ -147,21 +147,32 @@
             android:layout_marginTop="6dp"
             android:text="@string/feedback_section_subtitle" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/githubTokenLayout"
-            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        <TextView
+            android:id="@+id/githubAccountStatus"
+            style="@style/TextAppearance.Sushi.Caption"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:hint="@string/feedback_token_label"
-            app:passwordToggleEnabled="true">
+            android:layout_marginTop="10dp"
+            android:text="@string/github_not_signed_in" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/githubTokenInput"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="textPassword" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/githubSignInButton"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/github_sign_in_button"
+            app:icon="@drawable/ic_login"
+            app:iconGravity="textStart" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/githubSignOutButton"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/github_sign_out_button"
+            android:visibility="gone" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/sendFeedbackButton"

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -351,6 +351,7 @@
     <string name="feedback_section_subtitle">Lähetä palaute suoraan projektin GitHub-issueiksi. Kirjaudu ensin GitHubiin.</string>
     <string name="github_not_signed_in">Ei kirjautunut sisään</string>
     <string name="github_signed_in_as">Kirjautuneena: %1$s</string>
+    <string name="github_signed_in_generic">Kirjautuneena</string>
     <string name="github_sign_in_button">Kirjaudu GitHubiin</string>
     <string name="github_sign_out_button">Kirjaudu ulos</string>
     <string name="github_device_flow_instructions">Avaa github.com/login/device millä tahansa laitteella ja syötä tämä koodi:</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -348,14 +348,24 @@
 
     <!-- In-app feedback (GitHub issues) -->
     <string name="feedback_section_title">Palaute</string>
-    <string name="feedback_section_subtitle">Lähetä palaute suoraan projektin GitHub-issueiksi. Vaatii fine-grained personal access tokenin, jolla on Issues-oikeus sovelluksen repoon.</string>
-    <string name="feedback_token_label">GitHub-token</string>
+    <string name="feedback_section_subtitle">Lähetä palaute suoraan projektin GitHub-issueiksi. Kirjaudu ensin GitHubiin.</string>
+    <string name="github_not_signed_in">Ei kirjautunut sisään</string>
+    <string name="github_signed_in_as">Kirjautuneena: %1$s</string>
+    <string name="github_sign_in_button">Kirjaudu GitHubiin</string>
+    <string name="github_sign_out_button">Kirjaudu ulos</string>
+    <string name="github_device_flow_instructions">Avaa github.com/login/device millä tahansa laitteella ja syötä tämä koodi:</string>
+    <string name="github_device_flow_open_button">Avaa github.com/login/device</string>
+    <string name="github_device_flow_waiting">Odotetaan hyväksyntää\u2026</string>
+    <string name="github_device_flow_failed">Kirjautuminen epäonnistui: %1$s</string>
+    <string name="github_device_flow_denied">Kirjautuminen hylättiin</string>
+    <string name="github_device_flow_expired">Koodi vanhentui \u2014 yritä uudestaan</string>
+    <string name="github_device_flow_success">Kirjautuneena: %1$s</string>
     <string name="feedback_send_button">Lähetä palautetta</string>
     <string name="feedback_dialog_title">Lähetä palautetta</string>
     <string name="feedback_text_hint">Mitä tapahtui tai mikä voisi olla paremmin?</string>
     <string name="feedback_include_device_info">Liitä sovellusversio ja laitetiedot</string>
     <string name="feedback_send">Lähetä</string>
-    <string name="feedback_missing_token">Lisää ensin GitHub-token asetuksiin</string>
+    <string name="feedback_missing_token">Kirjaudu ensin GitHubiin asetuksissa</string>
     <string name="feedback_missing_text">Kirjoita ensin jotain</string>
     <string name="feedback_default_title">Palaute sovelluksesta</string>
     <string name="feedback_sent">Palaute lähetetty: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -417,14 +417,24 @@
     </plurals>
     <!-- In-app feedback (GitHub issues) -->
     <string name="feedback_section_title">Feedback</string>
-    <string name="feedback_section_subtitle">Send feedback straight to the project\'s GitHub issues. Requires a fine-grained personal access token with Issues permission on the app repository.</string>
-    <string name="feedback_token_label">GitHub token</string>
+    <string name="feedback_section_subtitle">Send feedback straight to the project\'s GitHub issues. Sign in with GitHub once to enable this.</string>
+    <string name="github_not_signed_in">Not signed in</string>
+    <string name="github_signed_in_as">Signed in as %1$s</string>
+    <string name="github_sign_in_button">Sign in with GitHub</string>
+    <string name="github_sign_out_button">Sign out</string>
+    <string name="github_device_flow_instructions">Go to github.com/login/device on any device and enter this code:</string>
+    <string name="github_device_flow_open_button">Open github.com/login/device</string>
+    <string name="github_device_flow_waiting">Waiting for authorization\u2026</string>
+    <string name="github_device_flow_failed">Sign-in failed: %1$s</string>
+    <string name="github_device_flow_denied">Sign-in was denied</string>
+    <string name="github_device_flow_expired">Code expired \u2014 try again</string>
+    <string name="github_device_flow_success">Signed in as %1$s</string>
     <string name="feedback_send_button">Send feedback</string>
     <string name="feedback_dialog_title">Send feedback</string>
     <string name="feedback_text_hint">What happened, or what could be better?</string>
     <string name="feedback_include_device_info">Include app version and device info</string>
     <string name="feedback_send">Send</string>
-    <string name="feedback_missing_token">Add a GitHub token in Settings first</string>
+    <string name="feedback_missing_token">Sign in with GitHub in Settings first</string>
     <string name="feedback_missing_text">Write something first</string>
     <string name="feedback_default_title">Feedback from app</string>
     <string name="feedback_sent">Feedback sent: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,7 @@
     <string name="feedback_section_subtitle">Send feedback straight to the project\'s GitHub issues. Sign in with GitHub once to enable this.</string>
     <string name="github_not_signed_in">Not signed in</string>
     <string name="github_signed_in_as">Signed in as %1$s</string>
+    <string name="github_signed_in_generic">Signed in</string>
     <string name="github_sign_in_button">Sign in with GitHub</string>
     <string name="github_sign_out_button">Sign out</string>
     <string name="github_device_flow_instructions">Go to github.com/login/device on any device and enter this code:</string>


### PR DESCRIPTION
## Summary

Follow-up to #145. Pasting a fine-grained PAT on a phone keyboard was the wrong shape for a feature whose whole point is working from the phone. Replaces it with GitHub's **OAuth Device Flow**:

- User taps **Sign in with GitHub** in Settings
- App shows a short code + "Open github.com/login/device" button
- User approves on any browser (or the GitHub app) by entering the code
- App polls in the background and stores the resulting token in `SecurePrefs`, same as before

No client secret is embedded — device flow doesn't require one, so the public OAuth App `client_id` is safe to ship in the APK. Scope is `public_repo` (the target repo is public).

`GitHubIssueClient` is unchanged — it already sends the stored token as a Bearer header, which works identically whether the token came from a PAT or OAuth.

## Setup required (one-time, already done)

- Registered a GitHub OAuth App with Device Flow enabled, `client_id` embedded in `GitHubAuthManager`

## UX

Does this PR change the UI?
- [x] Yes — Figma design updated on the same proposal card: https://www.figma.com/design/heP71zbxhc6Mtgpghp0dDw/Sushi?node-id=60-2 (mocks now show the sign-in button + device-code dialog instead of the token field)

## Test plan

- [x] `compileDebugKotlin` + `processDebugResources` pass locally
- [ ] CI: build + API 37 emulator tests green
- [ ] Manual: sign in on device, verify issue creation still works, sign out clears state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMDwyKJLRTEmfy1gvEW59z