### PR TITLE
fix(ui): keep switch-host button reachable once a host is active

### DIFF
--- a/app/src/main/java/net/hlan/sushi/MainActivity.kt
+++ b/app/src/main/java/net/hlan/sushi/MainActivity.kt
@@ -904,7 +904,11 @@ class MainActivity : AppCompatActivity() {
             getString(R.string.action_start_session_host, displayTarget)
         }
         binding.returnTerminalButton.visibility = if (config == null) View.GONE else View.VISIBLE
-        binding.configureHostButton.visibility = if (config == null) View.VISIBLE else View.GONE
+        binding.configureHostButton.text = if (config == null) {
+            getString(R.string.action_configure_host)
+        } else {
+            getString(R.string.action_switch_host)
+        }
 
         refreshPlaysPageState()
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -141,7 +141,6 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/action_configure_host"
-                    android:visibility="gone"
                     app:icon="@drawable/ic_dns"
                     app:iconGravity="textStart" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="phrase_copied_toast">Copied: %1$s</string>
     <string name="action_return_terminal">Return to terminal</string>
     <string name="action_configure_host">Configure host</string>
+    <string name="action_switch_host">Switch host</string>
     <string name="action_end_session">End session</string>
     <string name="action_open_terminal_mode">Open dedicated terminal</string>
     <string name="action_copy_log">Copy log</string>


### PR DESCRIPTION
## Summary
- The "Configure host" button on the main screen was hidden as soon as a host became active, so once a user had one host set up there was no way back to the host list from the home screen — the only remaining path was a mislabeled "Add Host" button on the Plays tab.
- The button is now always visible and relabels itself to "Switch host" once a host is configured, restoring a discoverable way to pick a different saved host.

## Test plan
- [x] `./gradlew compileDebugKotlin` passes
- [ ] Manual check: with a host configured, confirm the "Switch host" button is visible on the main screen and opens the host list
- [ ] Manual check: with no host configured, confirm the button still reads "Configure host" and opens the host-edit screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M1rEqyqXi6QwCDwY2uMiv